### PR TITLE
feat: support for solution-style tsconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ tsconfck parse src/index.ts
 tsconfck parse src/index.ts > output.json
 ```
 
+#### parse-result
+
+```shell
+# print content of ParseResult on stdout
+tsconfck parse-result src/index.ts
+
+# print to file
+tsconfck parse-result src/index.ts > output.json
+```
+
 #### help
 
 ```shell

--- a/bin/tsconfck.js
+++ b/bin/tsconfck.js
@@ -5,7 +5,7 @@ import * as process from 'process';
 const HELP_TEXT = `
 Usage: tsconfck <command> <file>
 
-Commands: find, parse
+Commands: find, parse, parse-result
 
 Examples:
 > tsconfck find src/index.ts
@@ -13,14 +13,19 @@ Examples:
 
 > tsconfck parse src/index.ts
 >{
->  ...json...
+>  ... tsconfig json
 >}
 
 > tsconfck parse src/index.ts > parsed.tsconfig.json
+
+> tsconfck parse-result src/index.ts
+>{
+>  ... ParseResult json
+>}
 `;
 
 const HELP_ARGS = ['-h', '--help', '-?', 'help'];
-const COMMANDS = ['find', 'parse'];
+const COMMANDS = ['find', 'parse', 'parse-result'];
 function needsHelp(args) {
 	if (args.some((arg) => HELP_ARGS.includes(arg))) {
 		return HELP_TEXT;
@@ -43,6 +48,8 @@ async function main() {
 		return find(file);
 	} else if (command === 'parse') {
 		return JSON.stringify((await parse(file)).tsconfig, null, 2);
+	} else if (command === 'parse-result') {
+		return JSON.stringify(await parse(file), null, 2);
 	}
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,11 +45,19 @@ interface ParseResult {
      */
     tsconfig: any;
     /**
+     * ParseResult for parent solution
+     */
+    solution?: ParseResult;
+    /**
+     * ParseResults for all tsconfig files referenced in a solution
+     */
+    referenced?: ParseResult[];
+    /**
      * ParseResult for all tsconfig files
      *
      * [a,b,c] where a extends b and b extends c
      */
-    extended?: Omit<ParseResult, 'extended'>[];
+    extended?: ParseResult[];
 }
 ```
 
@@ -88,6 +96,14 @@ interface ParseNativeResult {
      * parsed result, including merged values from extended
      */
     tsconfig: any;
+    /**
+     * ParseResult for parent solution
+     */
+    solution?: ParseResult;
+    /**
+     * ParseResults for all tsconfig files referenced in a solution
+     */
+    referenced?: ParseResult[];
     /**
      * full output of ts.parseJsonConfigFileContent
      */

--- a/docs/api.md
+++ b/docs/api.md
@@ -99,11 +99,11 @@ interface ParseNativeResult {
     /**
      * ParseResult for parent solution
      */
-    solution?: ParseResult;
+    solution?: ParseNativeResult;
     /**
-     * ParseResults for all tsconfig files referenced in a solution
+     * ParseNativeResults for all tsconfig files referenced in a solution
      */
-    referenced?: ParseResult[];
+    referenced?: ParseNativeResult[];
     /**
      * full output of ts.parseJsonConfigFileContent
      */

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dev": "pnpm run build:ci -- --watch src",
     "build:ci": "rimraf dist && tsup-node src/index.ts --format esm,cjs --no-splitting",
     "build": "pnpm run build:ci -- --dts --sourcemap && node scripts/generate-api-docs.js",
-    "test": "node --experimental-loader ts-node/esm node_modules/uvu/bin.js tests -i fixtures -i temp -i util",
+    "test": "node --experimental-loader ts-node/esm node_modules/uvu/bin.js tests -i fixtures/ -i temp/ -i util/",
     "test:watch": "pnpm test; watchlist tests src -- pnpm test",
     "lint": "eslint --ignore-path .gitignore '**/*.{cjs,js,ts,md}'",
     "lint:fix": "pnpm run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dev": "pnpm run build:ci -- --watch src",
     "build:ci": "rimraf dist && tsup-node src/index.ts --format esm,cjs --no-splitting",
     "build": "pnpm run build:ci -- --dts --sourcemap && node scripts/generate-api-docs.js",
-    "test": "node --experimental-loader ts-node/esm node_modules/uvu/bin.js tests -i fixtures/ -i temp/ -i util/",
+    "test": "node --experimental-loader ts-node/esm node_modules/uvu/bin.js tests -i fixtures -i temp -i util/",
     "test:watch": "pnpm test; watchlist tests src -- pnpm test",
     "lint": "eslint --ignore-path .gitignore '**/*.{cjs,js,ts,md}'",
     "lint:fix": "pnpm run lint -- --fix",

--- a/src/parse-native.ts
+++ b/src/parse-native.ts
@@ -152,6 +152,12 @@ export interface ParseNativeResult {
 	 * parsed result, including merged values from extended
 	 */
 	tsconfig: any;
+
+	/**
+	 * ParseResult for all referenced tsconfig files
+	 */
+	referenced?: Pick<ParseNativeResult, 'filename' | 'tsconfig'>[];
+
 	/**
 	 * full output of ts.parseJsonConfigFileContent
 	 */

--- a/src/util.ts
+++ b/src/util.ts
@@ -35,6 +35,7 @@ export async function resolveTSConfig(filename: string): Promise<string | void> 
 	throw new Error(`no tsconfig file found for ${filename}`);
 }
 
+const POSIX_SEP_RE = new RegExp('\\' + path.posix.sep, 'g');
 /**
  * convert posix separator to native separator
  *
@@ -47,10 +48,11 @@ export async function resolveTSConfig(filename: string): Promise<string | void> 
  */
 export function posix2native(filename: string) {
 	return path.posix.sep !== path.sep && filename.includes(path.posix.sep)
-		? filename.split(path.posix.sep).join(path.sep)
+		? filename.replace(POSIX_SEP_RE, path.sep)
 		: filename;
 }
 
+const NATIVE_SEP_RE = new RegExp('\\' + path.sep, 'g');
 /**
  * convert native separator to posix separator
  *
@@ -63,7 +65,7 @@ export function posix2native(filename: string) {
  */
 export function native2posix(filename: string) {
 	return path.posix.sep !== path.sep && filename.includes(path.sep)
-		? filename.split(path.sep).join(path.posix.sep)
+		? filename.replace(NATIVE_SEP_RE, path.posix.sep)
 		: filename;
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -218,7 +218,7 @@ function pattern2regex(resolvedPattern: string): RegExp {
 		if (char === '*') {
 			if (resolvedPattern[i + 1] === '*' && resolvedPattern[i + 2] === '/') {
 				i += 2;
-				regexStr += '(?:[^\\/]*\\/*)*'; // zero or more path segments
+				regexStr += '(?:[^\\/]*\\/)*'; // zero or more path segments
 				continue;
 			}
 			regexStr += '[^\\/]*';

--- a/src/util.ts
+++ b/src/util.ts
@@ -118,7 +118,7 @@ export function resolveSolutionTSConfig(filename: string, result: ParseResult): 
 }
 
 function isIncluded(filename: string, result: ParseResult): boolean {
-	const dir = path.dirname(result.filename);
+	const dir = native2posix(path.dirname(result.filename));
 	const files = (result.tsconfig.files || []).map((file: string) => resolve2posix(dir, file));
 	const absoluteFilename = resolve2posix(null, filename);
 	if (files.includes(filename)) {
@@ -141,7 +141,7 @@ function isIncluded(filename: string, result: ParseResult): boolean {
  * test filenames agains glob patterns in tsconfig
  *
  * @param filename {string} posix style abolute path to filename to test
- * @param dir {string} absolute path to directory of tsconfig containing patterns
+ * @param dir {string} posix style absolute path to directory of tsconfig containing patterns
  * @param patterns {string[]} glob patterns to match against
  * @returns {boolean} true when at least one pattern matches filename
  */

--- a/src/util.ts
+++ b/src/util.ts
@@ -125,19 +125,27 @@ function isIncluded(filename: string, result: ParseResult): boolean {
 		return true;
 	}
 
-	const isIncluded = isMatched(
+	const isIncluded = isGlobMatch(
 		absoluteFilename,
 		dir,
 		result.tsconfig.include || (result.tsconfig.files ? [] : [GLOB_ALL_PATTERN])
 	);
 	if (isIncluded) {
-		const isExcluded = isMatched(absoluteFilename, dir, result.tsconfig.exclude || []);
+		const isExcluded = isGlobMatch(absoluteFilename, dir, result.tsconfig.exclude || []);
 		return !isExcluded;
 	}
 	return false;
 }
 
-function isMatched(filename: string, dir: string, patterns: string[]): boolean {
+/**
+ * test filenames agains glob patterns in tsconfig
+ *
+ * @param filename {string} posix style abolute path to filename to test
+ * @param dir {string} absolute path to directory of tsconfig containing patterns
+ * @param patterns {string[]} glob patterns to match against
+ * @returns {boolean} true when at least one pattern matches filename
+ */
+export function isGlobMatch(filename: string, dir: string, patterns: string[]): boolean {
 	return patterns.some((pattern) => {
 		// filename must end with part of pattern that comes after last wildcard
 		const len = pattern.length;
@@ -150,6 +158,8 @@ function isMatched(filename: string, dir: string, patterns: string[]): boolean {
 				break;
 			}
 		}
+
+		// if pattern does not end with wildcard, filename must end with pattern after last wildcard
 		if (lastWildcardIndex < len - 1 && !filename.endsWith(pattern.slice(lastWildcardIndex + 1))) {
 			return false;
 		}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,7 @@
 import path from 'path';
 import { promises as fs } from 'fs';
+import { ParseResult } from './parse';
+import { ParseNativeResult } from './parse-native';
 
 // hide dynamic import from ts transform to prevent it turning into a require
 // see https://github.com/microsoft/TypeScript/issues/43329#issuecomment-811606238
@@ -64,4 +66,65 @@ export function native2posix(filename: string) {
 	return path.posix.sep !== path.sep && filename.includes(path.sep)
 		? filename.split(path.sep).join(path.posix.sep)
 		: filename;
+}
+
+export function resolveReferencedTSConfigFiles(result: ParseResult | ParseNativeResult): string[] {
+	if (!result.tsconfig.references) {
+		return [];
+	}
+	const dir = path.dirname(result.filename);
+	return result.tsconfig.references.map((ref: { path: string }) => {
+		const refPath = ref.path.endsWith('.json')
+			? ref.path
+			: path.posix.join(ref.path, 'tsconfig.json');
+		return path.posix.resolve(dir, refPath);
+	});
+}
+
+export function findTSConfigForFileInSolution(
+	filename: string,
+	solution: ParseResult | ParseNativeResult
+): any {
+	if (isIncluded(filename, solution)) {
+		return solution;
+	}
+	return solution.referenced?.find((referenced) => isIncluded(filename, referenced));
+}
+
+function isIncluded(filename: string, result: ParseResult | ParseNativeResult): boolean {
+	const dir = path.dirname(result.filename);
+	const files = (result.tsconfig.files || []).map((file: string) =>
+		path.posix.resolve(dir, native2posix(file))
+	);
+	if (files.includes(filename)) {
+		return true;
+	}
+	const isIncluded = isMatched(
+		filename,
+		dir,
+		result.tsconfig.include || (result.tsconfig.files ? [] : ['*/**'])
+	);
+	if (isIncluded) {
+		const isExcluded = isMatched(filename, dir, result.tsconfig.exclude || []);
+		return !isExcluded;
+	}
+	return false;
+}
+
+function isMatched(filename: string, dir: string, patterns: string[]): boolean {
+	return patterns.some((pattern) => {
+		const resolvedPattern = path.posix.resolve(dir, native2posix(pattern));
+		if (pattern.includes('*') || pattern.includes('?')) {
+			let regexp = resolvedPattern
+				.replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape all regex chars except * and ?
+				.replace(/\*\*/g, '(?:[^\\/]*\\/*)*') // replace all ** with greedy multiple path segment group
+				.replace(/\*/g, '(?:[^\\/]*)') // replace all * with greedy group path segment
+				.replace(/\?/g, '(?:.)'); // replace ? with single char group
+			if (pattern.endsWith('*')) {
+				regexp += '(?:\\.ts|\\.tsx|\\.d\\.ts)';
+			}
+			return filename.match(regexp);
+		}
+		return resolvedPattern === filename;
+	});
 }

--- a/tests/fixtures/parse/solution/mixed/src/foo.spec.ts
+++ b/tests/fixtures/parse/solution/mixed/src/foo.spec.ts
@@ -1,0 +1,9 @@
+import { foo } from './foo.js';
+import * as assert from 'assert';
+
+function test() {
+	const actual = foo();
+	const expected = 'foo';
+	assert.strictEqual(actual, expected);
+}
+test();

--- a/tests/fixtures/parse/solution/mixed/src/foo.spec.ts.expected.json
+++ b/tests/fixtures/parse/solution/mixed/src/foo.spec.ts.expected.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "strict": false,
+    "strictNullChecks": true
+  },
+  "compileOnSave": false
+}

--- a/tests/fixtures/parse/solution/mixed/src/foo.spec.ts.expected.json
+++ b/tests/fixtures/parse/solution/mixed/src/foo.spec.ts.expected.json
@@ -1,5 +1,6 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "./tsconfig.base",
+  "include": ["src/**/*.spec.ts"],
   "compilerOptions": {
     "composite": true,
     "strict": false,

--- a/tests/fixtures/parse/solution/mixed/src/foo.ts
+++ b/tests/fixtures/parse/solution/mixed/src/foo.ts
@@ -1,0 +1,3 @@
+export function foo() {
+	return 'foo';
+}

--- a/tests/fixtures/parse/solution/mixed/src/foo.ts.expected.json
+++ b/tests/fixtures/parse/solution/mixed/src/foo.ts.expected.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "strict": true,
+    "strictNullChecks": true
+  },
+  "compileOnSave": false
+}

--- a/tests/fixtures/parse/solution/mixed/src/foo.ts.expected.json
+++ b/tests/fixtures/parse/solution/mixed/src/foo.ts.expected.json
@@ -1,5 +1,7 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "./tsconfig.base",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts"],
   "compilerOptions": {
     "composite": true,
     "strict": true,

--- a/tests/fixtures/parse/solution/mixed/tsconfig.base.json
+++ b/tests/fixtures/parse/solution/mixed/tsconfig.base.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "strictNullChecks": true
+  }
+}

--- a/tests/fixtures/parse/solution/mixed/tsconfig.json
+++ b/tests/fixtures/parse/solution/mixed/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "include": [],
+  "references": [
+    {"path": "./tsconfig.src.json"},
+    {"path": "./tsconfig.test.json"}
+  ]
+}

--- a/tests/fixtures/parse/solution/mixed/tsconfig.src.json
+++ b/tests/fixtures/parse/solution/mixed/tsconfig.src.json
@@ -1,0 +1,8 @@
+{
+  "extends": "tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts"],
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/tests/fixtures/parse/solution/mixed/tsconfig.src.json
+++ b/tests/fixtures/parse/solution/mixed/tsconfig.src.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig.base.json",
+  "extends": "./tsconfig.base",
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.spec.ts"],
   "compilerOptions": {

--- a/tests/fixtures/parse/solution/mixed/tsconfig.test.json
+++ b/tests/fixtures/parse/solution/mixed/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "tsconfig.base.json",
+  "include": ["src/**/*.spec.ts"],
+  "compilerOptions": {
+    "strict": false
+  }
+}

--- a/tests/fixtures/parse/solution/mixed/tsconfig.test.json
+++ b/tests/fixtures/parse/solution/mixed/tsconfig.test.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig.base.json",
+  "extends": "./tsconfig.base",
   "include": ["src/**/*.spec.ts"],
   "compilerOptions": {
     "strict": false

--- a/tests/fixtures/parse/solution/simple/src/foo.ts
+++ b/tests/fixtures/parse/solution/simple/src/foo.ts
@@ -1,0 +1,3 @@
+export function foo() {
+	return 'foo';
+}

--- a/tests/fixtures/parse/solution/simple/src/foo.ts.expected.json
+++ b/tests/fixtures/parse/solution/simple/src/foo.ts.expected.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "strict": true,
+    "strictNullChecks": true
+  },
+  "compileOnSave": false
+}

--- a/tests/fixtures/parse/solution/simple/src/foo.ts.expected.json
+++ b/tests/fixtures/parse/solution/simple/src/foo.ts.expected.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig.base",
   "compilerOptions": {
     "composite": true,
     "strict": true,

--- a/tests/fixtures/parse/solution/simple/src/tsconfig.json
+++ b/tests/fixtures/parse/solution/simple/src/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/tests/fixtures/parse/solution/simple/src/tsconfig.json
+++ b/tests/fixtures/parse/solution/simple/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig.base",
   "compilerOptions": {
     "strict": true
   }

--- a/tests/fixtures/parse/solution/simple/tests/foo.ts
+++ b/tests/fixtures/parse/solution/simple/tests/foo.ts
@@ -1,0 +1,9 @@
+import { foo } from '../src/foo.js';
+import * as assert from 'assert';
+
+function test() {
+	const actual = foo();
+	const expected = 'foo';
+	assert.strictEqual(actual, expected);
+}
+test();

--- a/tests/fixtures/parse/solution/simple/tests/foo.ts.expected.json
+++ b/tests/fixtures/parse/solution/simple/tests/foo.ts.expected.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "strict": false,
+    "strictNullChecks": true
+  },
+  "compileOnSave": false
+}

--- a/tests/fixtures/parse/solution/simple/tests/foo.ts.expected.json
+++ b/tests/fixtures/parse/solution/simple/tests/foo.ts.expected.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig.base",
   "compilerOptions": {
     "composite": true,
     "strict": false,

--- a/tests/fixtures/parse/solution/simple/tests/tsconfig.json
+++ b/tests/fixtures/parse/solution/simple/tests/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "strict": false
+  }
+}

--- a/tests/fixtures/parse/solution/simple/tests/tsconfig.json
+++ b/tests/fixtures/parse/solution/simple/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../tsconfig.base",
   "compilerOptions": {
     "strict": false
   }

--- a/tests/fixtures/parse/solution/simple/tsconfig.base.json
+++ b/tests/fixtures/parse/solution/simple/tsconfig.base.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "strictNullChecks": true
+  }
+}

--- a/tests/fixtures/parse/solution/simple/tsconfig.json
+++ b/tests/fixtures/parse/solution/simple/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "include": [],
+  "references": [
+    {"path": "./src"},
+    {"path": "./tests"}
+  ]
+}

--- a/tests/parse-native.ts
+++ b/tests/parse-native.ts
@@ -79,6 +79,29 @@ test('should resolve with expected for valid tsconfig.json', async () => {
 	}
 });
 
+test('should resolve with expected tsconfig.json for ts file that is part of a solution', async () => {
+	const samples = await glob('tests/fixtures/parse/solution/**/*.ts');
+	for (const filename of samples) {
+		const expectedFilename = `${filename}.expected.json`;
+		let actual: ParseNativeResult;
+		let expected;
+		try {
+			expected = JSON.parse(await fs.readFile(path.resolve(expectedFilename), 'utf-8'));
+		} catch (e) {
+			assert.unreachable(`unexpected exception parsing ${expectedFilename}: ${e}`);
+		}
+		try {
+			actual = await parseNative(filename);
+			assert.equal(actual.tsconfig, expected, `testfile: ${filename}`);
+		} catch (e) {
+			if (e.code === 'ERR_ASSERTION') {
+				throw e;
+			}
+			assert.unreachable(`parsing ${filename} failed: ${e}`);
+		}
+	}
+});
+
 test('should resolve with tsconfig that is isomorphic', async () => {
 	const tempDir = await copyFixtures(
 		'parse/valid',

--- a/tests/parse.ts
+++ b/tests/parse.ts
@@ -79,6 +79,29 @@ test('should resolve with expected for valid tsconfig.json', async () => {
 	}
 });
 
+test('should resolve with expected tsconfig.json for ts file that is part of a solution', async () => {
+	const samples = await glob('tests/fixtures/parse/solution/**/*.ts');
+	for (const filename of samples) {
+		const expectedFilename = `${filename}.expected.json`;
+		let actual: ParseResult;
+		let expected;
+		try {
+			expected = JSON.parse(await fs.readFile(path.resolve(expectedFilename), 'utf-8'));
+		} catch (e) {
+			assert.unreachable(`unexpected exception parsing ${expectedFilename}: ${e}`);
+		}
+		try {
+			actual = await parse(filename);
+			assert.equal(actual.tsconfig, expected, `testfile: ${filename}`);
+		} catch (e) {
+			if (e.code === 'ERR_ASSERTION') {
+				throw e;
+			}
+			assert.unreachable(`parsing ${filename} failed: ${e}`);
+		}
+	}
+});
+
 test('should resolve with tsconfig that is isomorphic', async () => {
 	const tempDir = await copyFixtures(
 		'parse/valid',

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,0 +1,86 @@
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+
+import { isGlobMatch } from '../src/util.js';
+const test_isMatched = suite('isGlobMatch');
+
+const IS_MATCHED_DATA = [
+	{
+		files: [
+			{ name: '/src/bar.ts', expected: true },
+			{ name: '/src/baz.tsx', expected: true },
+			{ name: '/src/foo/bar.ts', expected: true },
+			{ name: '/src/foo/bar/baz.tsx', expected: true },
+			{ name: '/src/qoox.txt', expected: false },
+			{ name: '/xxx/qoox.txt', expected: false },
+			{ name: '/xxx/bar.ts', expected: false },
+			{ name: '/xxx/bar.tsx', expected: false },
+			{ name: '/bar.ts', expected: false },
+			{ name: '/bar.tsx', expected: false }
+		],
+		dir: '/src',
+		patterns: ['**/*']
+	},
+	{
+		files: [
+			{ name: '/foo/src/a/bar.ts', expected: true },
+			{ name: '/foo/src/foo/a/bar/baz.tsx', expected: true },
+			{ name: '/foo/src/foo/a/bar.ts', expected: true },
+			{ name: '/foo/src/foo/bar/a/baz.tsx', expected: true },
+			{ name: '/foo/src/a/bar.txt', expected: false },
+			{ name: '/foo/src/foo/abar/baz.tsx', expected: false },
+			{ name: '/foo/src/foo/abar.ts', expected: false },
+			{ name: '/foo/src/foo/bar/a/baz.txt', expected: false },
+			{ name: '/foo/src/not-a/bar.ts', expected: true }
+		],
+		dir: '/foo/src',
+		patterns: ['/foo/src/**/a/**/*']
+	},
+	{
+		files: [
+			{ name: '/foo/src/bar.ts', expected: true },
+			{ name: '/foo/src/foo/a/bar/baz.tsx', expected: false },
+			{ name: '/foo/src/foo/a/bar.ts', expected: false },
+			{ name: '/foo/bar.ts', expected: false }
+		],
+		dir: '/foo/src',
+		patterns: ['/foo/src/*.ts']
+	},
+	{
+		files: [
+			{ name: '/foo/src/foo/bar.ts', expected: true },
+			{ name: '/foo/bar.ts', expected: false },
+			{ name: '/foo/src/bar.ts', expected: false },
+			{ name: '/foo/src/foo/a/bar.ts', expected: false }
+		],
+		dir: '/foo/src',
+		patterns: ['/foo/src/*/*']
+	},
+	{
+		files: [
+			{ name: '/foo/src/a/bar.ts', expected: true },
+			{ name: '/foo/src/b/bar.ts', expected: true },
+			{ name: '/foo/src/cc/bar.ts', expected: false },
+			{ name: '/foo/bar.ts', expected: false },
+			{ name: '/foo/src/bar.ts', expected: false },
+			{ name: '/foo/src/a/b/bar.ts', expected: false }
+		],
+		dir: '/foo/src',
+		patterns: ['/foo/src/?/*']
+	}
+];
+test_isMatched(`should work`, () => {
+	for (const { files, dir, patterns } of IS_MATCHED_DATA) {
+		for (const { name, expected } of files) {
+			const actual = isGlobMatch(name, dir, patterns);
+			try {
+				assert.is(actual, expected, `isGlobMatch("${name}","${dir}",${JSON.stringify(patterns)})`);
+			} catch (e) {
+				if (e.code === 'ERR_ASSERTION') {
+					throw e;
+				}
+			}
+		}
+	}
+});
+test_isMatched.run();

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,86 +1,78 @@
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
+import path from 'path';
+import os from 'os';
+import { isGlobMatch, resolve2posix } from '../src/util.js';
+const test_isGlobMatch = suite('isGlobMatch');
 
-import { isGlobMatch } from '../src/util.js';
-const test_isMatched = suite('isGlobMatch');
-
-const IS_MATCHED_DATA = [
+const GLOBMATCH_TEST_DATA = [
 	{
 		files: [
-			{ name: '/src/bar.ts', expected: true },
-			{ name: '/src/baz.tsx', expected: true },
-			{ name: '/src/foo/bar.ts', expected: true },
-			{ name: '/src/foo/bar/baz.tsx', expected: true },
-			{ name: '/src/qoox.txt', expected: false },
-			{ name: '/xxx/qoox.txt', expected: false },
-			{ name: '/xxx/bar.ts', expected: false },
-			{ name: '/xxx/bar.tsx', expected: false },
-			{ name: '/bar.ts', expected: false },
-			{ name: '/bar.tsx', expected: false }
+			{ name: 'bar.ts', expected: true },
+			{ name: 'baz.tsx', expected: true },
+			{ name: 'foo/bar.ts', expected: true },
+			{ name: 'foo/bar/baz.tsx', expected: true },
+			{ name: '../qoox.txt', expected: false },
+			{ name: '../xxx/qoox.txt', expected: false },
+			{ name: '../xxx/bar.ts', expected: false },
+			{ name: '../xxx/bar.tsx', expected: false },
+			{ name: '../bar.ts', expected: false },
+			{ name: '../bar.tsx', expected: false }
 		],
-		dir: '/src',
 		patterns: ['**/*']
 	},
 	{
 		files: [
-			{ name: '/foo/src/a/bar.ts', expected: true },
-			{ name: '/foo/src/foo/a/bar/baz.tsx', expected: true },
-			{ name: '/foo/src/foo/a/bar.ts', expected: true },
-			{ name: '/foo/src/foo/bar/a/baz.tsx', expected: true },
-			{ name: '/foo/src/a/bar.txt', expected: false },
-			{ name: '/foo/src/foo/abar/baz.tsx', expected: false },
-			{ name: '/foo/src/foo/abar.ts', expected: false },
-			{ name: '/foo/src/foo/bar/a/baz.txt', expected: false },
-			{ name: '/foo/src/not-a/bar.ts', expected: true }
+			{ name: 'a/bar.ts', expected: true },
+			{ name: 'foo/a/bar/baz.tsx', expected: true },
+			{ name: 'foo/a/bar.ts', expected: true },
+			{ name: 'foo/bar/a/baz.tsx', expected: true },
+			{ name: 'a/bar.txt', expected: false },
+			{ name: 'foo/abar/baz.tsx', expected: false },
+			{ name: 'foo/abar.ts', expected: false },
+			{ name: 'foo/bar/a/baz.txt', expected: false },
+			{ name: 'not-a/bar.ts', expected: false }
 		],
-		dir: '/foo/src',
-		patterns: ['/foo/src/**/a/**/*']
+		patterns: ['**/a/**/*']
 	},
 	{
 		files: [
-			{ name: '/foo/src/bar.ts', expected: true },
-			{ name: '/foo/src/foo/a/bar/baz.tsx', expected: false },
-			{ name: '/foo/src/foo/a/bar.ts', expected: false },
-			{ name: '/foo/bar.ts', expected: false }
+			{ name: 'bar.ts', expected: true },
+			{ name: 'foo/a/bar/baz.tsx', expected: false },
+			{ name: 'foo/a/bar.ts', expected: false },
+			{ name: '../foo/bar.ts', expected: false }
 		],
-		dir: '/foo/src',
-		patterns: ['/foo/src/*.ts']
+		patterns: ['*.ts']
 	},
 	{
 		files: [
-			{ name: '/foo/src/foo/bar.ts', expected: true },
-			{ name: '/foo/bar.ts', expected: false },
-			{ name: '/foo/src/bar.ts', expected: false },
-			{ name: '/foo/src/foo/a/bar.ts', expected: false }
+			{ name: 'foo/bar.ts', expected: true },
+			{ name: '../foo/bar.ts', expected: false },
+			{ name: 'bar.ts', expected: false },
+			{ name: 'foo/a/bar.ts', expected: false }
 		],
-		dir: '/foo/src',
-		patterns: ['/foo/src/*/*']
+		patterns: ['*/*']
 	},
 	{
 		files: [
-			{ name: '/foo/src/a/bar.ts', expected: true },
-			{ name: '/foo/src/b/bar.ts', expected: true },
-			{ name: '/foo/src/cc/bar.ts', expected: false },
-			{ name: '/foo/bar.ts', expected: false },
-			{ name: '/foo/src/bar.ts', expected: false },
-			{ name: '/foo/src/a/b/bar.ts', expected: false }
+			{ name: 'a/bar.ts', expected: true },
+			{ name: 'b/bar.ts', expected: true },
+			{ name: 'cc/bar.ts', expected: false },
+			{ name: '../foo/bar.ts', expected: false },
+			{ name: 'bar.ts', expected: false },
+			{ name: 'a/b/bar.ts', expected: false }
 		],
-		dir: '/foo/src',
-		patterns: ['/foo/src/?/*']
+		patterns: ['?/*']
 	}
 ];
-test_isMatched(`should work`, () => {
-	for (const { files, dir, patterns } of IS_MATCHED_DATA) {
+test_isGlobMatch(`should work`, () => {
+	const dir = path.join(os.homedir(), 'foo', 'src');
+	for (const { files, patterns } of GLOBMATCH_TEST_DATA) {
 		for (const { name, expected } of files) {
-			const actual = isGlobMatch(name, dir, patterns);
-			try {
-				assert.is(actual, expected, `isGlobMatch("${name}","${dir}",${JSON.stringify(patterns)})`);
-			} catch (e) {
-				if (e.code === 'ERR_ASSERTION') {
-					throw e;
-				}
-			}
+			const absName = resolve2posix(dir, name);
+			const actual = isGlobMatch(absName, dir, patterns);
+			assert.is(actual, expected, `isGlobMatch("${absName}","${dir}",${JSON.stringify(patterns)})`);
 		}
 	}
 });
-test_isMatched.run();
+test_isGlobMatch.run();

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -2,7 +2,7 @@ import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import path from 'path';
 import os from 'os';
-import { isGlobMatch, resolve2posix } from '../src/util.js';
+import { isGlobMatch, native2posix, resolve2posix } from '../src/util.js';
 const test_isGlobMatch = suite('isGlobMatch');
 
 const GLOBMATCH_TEST_DATA = [
@@ -66,7 +66,7 @@ const GLOBMATCH_TEST_DATA = [
 	}
 ];
 test_isGlobMatch(`should work`, () => {
-	const dir = path.join(os.homedir(), 'foo', 'src');
+	const dir = native2posix(path.join(os.homedir(), 'foo', 'src'));
 	for (const { files, patterns } of GLOBMATCH_TEST_DATA) {
 		for (const { name, expected } of files) {
 			const absName = resolve2posix(dir, name);


### PR DESCRIPTION
fixes #2 

The implementation is a "best effort" with some educated guesses on how typescript solutions actually work.

To be discussed:
1) regex based matching of patterns for include. Is that ok or should that be done with array/string scanning for perf and security reasons?
2) return value in case no reference including the input file was found? Only the solution as 'closest' tsconfig or no tsconfig because it doesn't include it
3) ParseResult interface structure. 2 props with referenced and solution feel a bit much for one feature  