### PR TITLE
Fix parsing individual solution config

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -24,8 +24,7 @@ export async function loadTS(): Promise<any> {
 }
 
 export async function resolveTSConfig(filename: string): Promise<string | void> {
-	const basename = path.basename(filename);
-	if (!basename.startsWith('tsconfig.') || !basename.endsWith('.json')) {
+	if (path.extname(filename) !== '.json') {
 		return;
 	}
 	const tsconfig = path.resolve(filename);

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,7 +25,7 @@ export async function loadTS(): Promise<any> {
 
 export async function resolveTSConfig(filename: string): Promise<string | void> {
 	const basename = path.basename(filename);
-	if (basename !== 'tsconfig.json') {
+	if (!basename.startsWith('tsconfig.') || !basename.endsWith('.json')) {
 		return;
 	}
 	const tsconfig = path.resolve(filename);

--- a/tests/fixtures/parse/solution/mixed/tsconfig.base.json.expected.json
+++ b/tests/fixtures/parse/solution/mixed/tsconfig.base.json.expected.json
@@ -1,7 +1,6 @@
 {
-    "compilerOptions": {
-      "composite": true,
-      "strictNullChecks": true
-    }
+  "compilerOptions": {
+    "composite": true,
+    "strictNullChecks": true
   }
-  
+}

--- a/tests/fixtures/parse/solution/mixed/tsconfig.base.json.expected.json
+++ b/tests/fixtures/parse/solution/mixed/tsconfig.base.json.expected.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+      "composite": true,
+      "strictNullChecks": true
+    }
+  }
+  

--- a/tests/fixtures/parse/solution/mixed/tsconfig.json.expected.json
+++ b/tests/fixtures/parse/solution/mixed/tsconfig.json.expected.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "include": [],
+  "references": [
+    {"path": "./tsconfig.src.json"},
+    {"path": "./tsconfig.test.json"}
+  ]
+}

--- a/tests/fixtures/parse/solution/mixed/tsconfig.src.json.expected.json
+++ b/tests/fixtures/parse/solution/mixed/tsconfig.src.json.expected.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.base",
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts"
+  ],
+  "compilerOptions": {
+    "strict": true,
+    "composite": true,
+    "strictNullChecks": true
+  }
+}

--- a/tests/fixtures/parse/solution/mixed/tsconfig.test.json.expected.json
+++ b/tests/fixtures/parse/solution/mixed/tsconfig.test.json.expected.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base",
+  "include": [
+    "src/**/*.spec.ts"
+  ],
+  "compilerOptions": {
+    "strict": false,
+    "composite": true,
+    "strictNullChecks": true
+  }
+}

--- a/tests/fixtures/parse/solution/simple/src/tsconfig.json.expected.json
+++ b/tests/fixtures/parse/solution/simple/src/tsconfig.json.expected.json
@@ -1,0 +1,11 @@
+{
+  "include": [
+    "./foo.ts"
+  ],
+  "extends": "../tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "composite": true,
+    "strictNullChecks": true
+  }
+}

--- a/tests/fixtures/parse/solution/simple/tests/tsconfig.json.expected.json
+++ b/tests/fixtures/parse/solution/simple/tests/tsconfig.json.expected.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base",
+  "compilerOptions": {
+    "strict": false,
+    "composite": true,
+    "strictNullChecks": true
+  }
+}

--- a/tests/fixtures/parse/solution/simple/tsconfig.base.json.expected.json
+++ b/tests/fixtures/parse/solution/simple/tsconfig.base.json.expected.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "strictNullChecks": true
+  }
+}

--- a/tests/fixtures/parse/solution/simple/tsconfig.json.expected.json
+++ b/tests/fixtures/parse/solution/simple/tsconfig.json.expected.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "include": [],
+  "references": [
+    {"path": "./src"},
+    {"path": "./tests"}
+  ]
+}

--- a/tests/parse-native.ts
+++ b/tests/parse-native.ts
@@ -96,6 +96,23 @@ test('should resolve with expected for valid tsconfig.json', async () => {
 	}
 });
 
+test('should resolve with expected tsconfig.json for valid tsconfig that is part of a solution', async () => {
+	const samples = await glob('tests/fixtures/parse/solution/**/tsconfig?(!(*.expected)).json');
+	for (const filename of samples) {
+		const expectedFilename = `${path.basename(filename)}.expected.json`;
+		const expected = await loadExpectedJSON(filename, expectedFilename);
+		try {
+			const actual = await parseNative(filename);
+			assert.equal(actual.tsconfig, expected, `testfile: ${filename}`);
+		} catch (e) {
+			if (e.code === 'ERR_ASSERTION') {
+				throw e;
+			}
+			assert.unreachable(`parsing ${filename} failed: ${e}`);
+		}
+	}
+});
+
 test('should resolve with expected tsconfig.json for ts file that is part of a solution', async () => {
 	const samples = await glob('tests/fixtures/parse/solution/**/*.{ts,mts,cts}');
 	for (const filename of samples) {

--- a/tests/parse.ts
+++ b/tests/parse.ts
@@ -89,6 +89,23 @@ test('should resolve with expected for valid tsconfig.json', async () => {
 	}
 });
 
+test('should resolve with expected tsconfig.json for valid tsconfig that is part of a solution', async () => {
+	const samples = await glob('tests/fixtures/parse/solution/**/tsconfig?(!(*.expected)).json');
+	for (const filename of samples) {
+		const expectedFilename = `${path.basename(filename)}.expected.json`;
+		const expected = await loadExpectedJSON(filename, expectedFilename);
+		try {
+			const actual = await parse(filename);
+			assert.equal(actual.tsconfig, expected, `testfile: ${filename}`);
+		} catch (e) {
+			if (e.code === 'ERR_ASSERTION') {
+				throw e;
+			}
+			assert.unreachable(`parsing ${filename} failed: ${e}`);
+		}
+	}
+});
+
 test('should resolve with expected tsconfig.json for ts file that is part of a solution', async () => {
 	const samples = await glob('tests/fixtures/parse/solution/**/*.{ts,mts,cts}');
 	for (const filename of samples) {


### PR DESCRIPTION
fixes #34 

This PR:
- relaxes the file name restriction on `resolveTsConfig` from an exact match on `tsconfig.json` to starting with `tsconfig.` and ending with `.json`
- add tests for `parse` and `parseNative` so we're sure the individual configs are properly parsed when requested, instead of loading the parent `tsconfig.json`