### PR TITLE
fix: resolve `extends` where value is missing the filename part. eg `"extends": "@tsconfig/node14"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "execa": "^6.1.0",
     "husky": "^7.0.4",
     "lint-staged": "^12.3.5",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ specifiers:
   execa: ^6.1.0
   husky: ^7.0.4
   lint-staged: ^12.3.5
-  minimist: ^1.2.5
+  minimist: ^1.2.6
   npm-run-all: ^4.1.5
   prettier: ^2.5.1
   rimraf: ^3.0.2
@@ -52,7 +52,7 @@ devDependencies:
   execa: 6.1.0
   husky: 7.0.4
   lint-staged: 12.3.5_enquirer@2.3.6
-  minimist: 1.2.5
+  minimist: 1.2.6
   npm-run-all: 4.1.5
   prettier: 2.5.1
   rimraf: 3.0.2
@@ -656,7 +656,7 @@ packages:
     resolution: {integrity: sha512-VXG6epB1yrLAvWVQpl92qF347/UXmncQj7J3U8kZEbdVZ1ZkQyr4hYeL/9RvcE8vVVdp53dY78Fd/3pqfRqI1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: '>=0.13'
+      esbuild: ^0.14.26
     dependencies:
       esbuild: 0.14.26
       load-tsconfig: 0.2.3
@@ -1933,12 +1933,12 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
     dependencies:
-      minimist: 1.2.5
+      minimist: 1.2.6
       neo-async: 2.6.2
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.15.2
+      uglify-js: 3.15.3
     dev: true
 
   /hard-rejection/2.1.0:
@@ -2546,8 +2546,8 @@ packages:
       kind-of: 6.0.3
     dev: true
 
-  /minimist/1.2.5:
-    resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
+  /minimist/1.2.6:
+    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
     dev: true
 
   /modify-values/1.0.1:
@@ -3564,8 +3564,8 @@ packages:
     hasBin: true
     dev: true
 
-  /uglify-js/3.15.2:
-    resolution: {integrity: sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==}
+  /uglify-js/3.15.3:
+    resolution: {integrity: sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -154,7 +154,7 @@ function resolveExtends(extended: string, from: string): string {
 			const fallbackExtended = path.join(extended, 'tsconfig.json');
 			return createRequire(from).resolve(fallbackExtended);
 		} catch (e) {
-			error = e
+			error = e;
 		}
 	}
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -141,21 +141,29 @@ async function parseExtends(result: TSConfckParseResult, cache?: Map<string, TSC
 }
 
 function resolveExtends(extended: string, from: string): string {
+	let error: any;
+
 	try {
 		return createRequire(from).resolve(extended);
 	} catch (e) {
+		error = e;
+	}
+
+	if (!path.isAbsolute(extended) && !extended.startsWith('./') && !extended.startsWith('../')) {
 		try {
 			const fallbackExtended = path.join(extended, 'tsconfig.json');
 			return createRequire(from).resolve(fallbackExtended);
-		} catch {
-			throw new TSConfckParseError(
-				`failed to resolve "extends":"${extended}" in ${from}`,
-				'EXTENDS_RESOLVE',
-				from,
-				e
-			);
+		} catch (e) {
+			error = e
 		}
 	}
+
+	throw new TSConfckParseError(
+		`failed to resolve "extends":"${extended}" in ${from}`,
+		'EXTENDS_RESOLVE',
+		from,
+		error
+	);
 }
 
 // references, extends and custom keys are not carried over

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -144,12 +144,17 @@ function resolveExtends(extended: string, from: string): string {
 	try {
 		return createRequire(from).resolve(extended);
 	} catch (e) {
-		throw new TSConfckParseError(
-			`failed to resolve "extends":"${extended}" in ${from}`,
-			'EXTENDS_RESOLVE',
-			from,
-			e
-		);
+		try {
+			const fallbackExtended = path.join(extended, 'tsconfig.json');
+			return createRequire(from).resolve(fallbackExtended);
+		} catch {
+			throw new TSConfckParseError(
+				`failed to resolve "extends":"${extended}" in ${from}`,
+				'EXTENDS_RESOLVE',
+				from,
+				e
+			);
+		}
 	}
 }
 

--- a/tests/fixtures/parse/invalid/extends-fallback-not-found/dir/expected.native.json
+++ b/tests/fixtures/parse/invalid/extends-fallback-not-found/dir/expected.native.json
@@ -1,0 +1,4 @@
+{
+  "message": "Cannot read file ",
+  "code": "TS 5083"
+}

--- a/tests/fixtures/parse/invalid/extends-fallback-not-found/dir/expected.native.json
+++ b/tests/fixtures/parse/invalid/extends-fallback-not-found/dir/expected.native.json
@@ -1,4 +1,0 @@
-{
-  "message": "Cannot read file ",
-  "code": "TS 5083"
-}

--- a/tests/fixtures/parse/invalid/extends-fallback-not-found/dir/tsconfig.json
+++ b/tests/fixtures/parse/invalid/extends-fallback-not-found/dir/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "compilerOptions": {}
+}

--- a/tests/fixtures/parse/invalid/extends-fallback-not-found/expected.native.json
+++ b/tests/fixtures/parse/invalid/extends-fallback-not-found/expected.native.json
@@ -1,0 +1,4 @@
+{
+  "message": "File './dir' not found.",
+  "code": "TS 6053"
+}

--- a/tests/fixtures/parse/invalid/extends-fallback-not-found/expected.txt
+++ b/tests/fixtures/parse/invalid/extends-fallback-not-found/expected.txt
@@ -1,0 +1,1 @@
+failed to resolve "extends":"./dir" in

--- a/tests/fixtures/parse/invalid/extends-fallback-not-found/tsconfig.json
+++ b/tests/fixtures/parse/invalid/extends-fallback-not-found/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./dir",
+    "compilerOptions": {
+      "types": ["foo"],
+      "strictNullChecks": true
+    },
+    "include": ["src/**/*"]
+  }
+  

--- a/tests/fixtures/parse/valid/with_extends/node_fallback/expected.json
+++ b/tests/fixtures/parse/valid/with_extends/node_fallback/expected.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@tsconfig/node12",
+  "compilerOptions": {
+    "types": ["foo"],
+    "strictNullChecks": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tests/fixtures/parse/valid/with_extends/node_fallback/expected.native.json
+++ b/tests/fixtures/parse/valid/with_extends/node_fallback/expected.native.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@tsconfig/node12",
+  "compilerOptions": {
+    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
+    "module": "commonjs",
+    "target": "es2019",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["foo"],
+    "strictNullChecks": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tests/fixtures/parse/valid/with_extends/node_fallback/tsconfig.json
+++ b/tests/fixtures/parse/valid/with_extends/node_fallback/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@tsconfig/node12",
+  "compilerOptions": {
+    "types": ["foo"],
+    "strictNullChecks": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tests/fixtures/parse/valid/with_extends/without_json_extension/expected.json
+++ b/tests/fixtures/parse/valid/with_extends/without_json_extension/expected.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.parent",
+  "compilerOptions": {
+    "types": ["foo"],
+    "strictNullChecks": true
+  },
+  "include": ["src/**/*", "foo.ts"]
+}

--- a/tests/fixtures/parse/valid/with_extends/without_json_extension/expected.native.json
+++ b/tests/fixtures/parse/valid/with_extends/without_json_extension/expected.native.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.parent",
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "types": ["foo"],
+    "noImplicitAny": true
+  },
+  "include": ["src/**/*", "foo.ts"],
+  "exclude": ["../**/foo/*"],
+  "watchOptions": {
+    "watchFile": "useFsEvents",
+    "watchDirectory": "useFsEvents",
+    "fallbackPolling": "dynamicPriority"
+  }
+}

--- a/tests/fixtures/parse/valid/with_extends/without_json_extension/tsconfig.json
+++ b/tests/fixtures/parse/valid/with_extends/without_json_extension/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.parent",
+  "compilerOptions": {
+    "types": ["foo"],
+    "strictNullChecks": true
+  },
+  "include": ["src/**/*", "foo.ts"]
+}

--- a/tests/parse-native.ts
+++ b/tests/parse-native.ts
@@ -237,7 +237,10 @@ test('should resolve with tsconfig that works when transpiling', async () => {
 });
 
 test('should reject with correct error position for invalid tsconfig.json', async () => {
-	const samples = await glob('tests/fixtures/parse/invalid/**/tsconfig.json');
+	let samples = await glob('tests/fixtures/parse/invalid/**/tsconfig.json');
+	samples = samples.filter(
+		(sample) => !sample.includes(path.join('extends-fallback-not-found', 'dir'))
+	);
 	for (const filename of samples) {
 		const expected = await loadExpectedJSON(filename, 'expected.native.json');
 		try {

--- a/tests/parse.ts
+++ b/tests/parse.ts
@@ -230,7 +230,10 @@ test('should resolve with tsconfig that works when transpiling', async () => {
 });
 
 test('should reject with correct error for invalid tsconfig.json', async () => {
-	const samples = await glob('tests/fixtures/parse/invalid/**/tsconfig.json');
+	let samples = await glob('tests/fixtures/parse/invalid/**/tsconfig.json');
+	samples = samples.filter(
+		(sample) => !sample.includes(path.join('extends-fallback-not-found', 'dir'))
+	);
 	for (const filename of samples) {
 		const expected = await loadExpectedTXT(filename);
 		try {


### PR DESCRIPTION
upstream: https://github.com/vitest-dev/vitest/issues/994 

And also need update in vite.