### PR TITLE
fix: support Node16 and NodeNext resolution

### DIFF
--- a/src/parse-native.ts
+++ b/src/parse-native.ts
@@ -188,7 +188,12 @@ function result2tsconfig(result: any, ts: any) {
 			{ name: 'module', enumeration: ts.ModuleKind },
 			{
 				name: 'moduleResolution',
-				enumeration: { 1: 'classic', 2: 'node' } /*ts.ModuleResolutionKind uses different names*/
+				enumeration: {
+					1: 'classic',
+					2: 'node',
+					3: 'node16',
+					99: 'nodenext'
+				} /*ts.ModuleResolutionKind uses different names*/
 			},
 			{
 				name: 'newLine',

--- a/tests/fixtures/parse/valid/node16/expected.json
+++ b/tests/fixtures/parse/valid/node16/expected.json
@@ -4,8 +4,8 @@
   "compilerOptions": {
     "types": ["foo"],
     "importsNotUsedAsValues": "error",
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "node16",
+    "moduleResolution": "node16",
     "newLine": "lf",
     "target": "esnext"
   },

--- a/tests/fixtures/parse/valid/node16/expected.native.json
+++ b/tests/fixtures/parse/valid/node16/expected.native.json
@@ -4,8 +4,8 @@
   "compilerOptions": {
     "types": ["foo"],
     "importsNotUsedAsValues": "error",
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "node16",
+    "moduleResolution": "node16",
     "newLine": "lf",
     "target": "esnext"
   },

--- a/tests/fixtures/parse/valid/node16/tsconfig.json
+++ b/tests/fixtures/parse/valid/node16/tsconfig.json
@@ -4,8 +4,8 @@
   "compilerOptions": {
     "types": ["foo"],
     "importsNotUsedAsValues": "error",
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "node16",
+    "moduleResolution": "node16",
     "newLine": "lf",
     "target": "esnext"
   },

--- a/tests/fixtures/parse/valid/nodenext/expected.json
+++ b/tests/fixtures/parse/valid/nodenext/expected.json
@@ -5,7 +5,7 @@
     "types": ["foo"],
     "importsNotUsedAsValues": "error",
     "module": "nodenext",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "newLine": "lf",
     "target": "esnext"
   },

--- a/tests/fixtures/parse/valid/nodenext/tsconfig.json
+++ b/tests/fixtures/parse/valid/nodenext/tsconfig.json
@@ -5,7 +5,7 @@
     "types": ["foo"],
     "importsNotUsedAsValues": "error",
     "module": "nodenext",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "newLine": "lf",
     "target": "esnext"
   },


### PR DESCRIPTION
Fix this error when using NodeNext

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at result2tsconfig (file:///home/cometkim/Workspace/src/github.com/reason-seoul/rescript-collection/node_modules/tsconfck/dist/index.js:672:83)
    at parseFile2 (file:///home/cometkim/Workspace/src/github.com/reason-seoul/rescript-collection/node_modules/tsconfck/dist/index.js:619:15)
    at parseNative (file:///home/cometkim/Workspace/src/github.com/reason-seoul/rescript-collection/node_modules/tsconfck/dist/index.js:586:20)

```