### PR TITLE
fix(findAll): ignore inaccessible directory error on windows

### DIFF
--- a/src/find-all.ts
+++ b/src/find-all.ts
@@ -45,7 +45,7 @@ function walk(
 			return;
 		}
 		// skip deleted or inaccessible directories
-		if (err && !(err.code === 'ENOENT' || err.code === 'EACCES')) {
+		if (err && !(err.code === 'ENOENT' || err.code === 'EACCES' || err.code === 'EPERM')) {
 			state.err = true;
 			done(err);
 		} else {


### PR DESCRIPTION
see #51  which handles EACCES, but on windows the error code can be EPERM  as well.