### PR TITLE
fix(parse): normalize parsing of compileOnSave to match native

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -91,6 +91,10 @@ function normalizeTSConfig(tsconfig: any, dir: string) {
 	if (tsconfig.compilerOptions?.baseUrl && !path.isAbsolute(tsconfig.compilerOptions.baseUrl)) {
 		tsconfig.compilerOptions.baseUrl = resolve2posix(dir, tsconfig.compilerOptions.baseUrl);
 	}
+	// remove compileOnSave if set to false
+	if (tsconfig.compileOnSave === false) {
+		delete tsconfig.compileOnSave;
+	}
 	return tsconfig;
 }
 


### PR DESCRIPTION
When `compileOnSave` is set to false in the tsconfig, `ts.parseJsonConfigFileContent` omits the option from the result, e.g.

```
{
  "compileOnSave": false,
  // ...
}
```

becomes

```
{
  // ...
}
```

It's a draft PR for now since it hasn't added any tests. I noticed that `toJson` and `parse` seem to share expected results for the most part so I wasn't sure the best way to add tests for just `parse`.