### PR TITLE
refactor!: ensure consistent casing in writing "tsconfig"

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ You can specify a root directory and provide a set of known tsconfig locations t
 ```js
 import { parse, findAll } from 'tsconfck';
 const root = '.';
-const tsConfigPaths = new Set([
+const tsconfigPaths = new Set([
 	...(await findAll(root, { skip: (dir) => dir === 'node_modules' || dir === '.git' }))
 ]);
 const cache = new Map();
-const parseOptions = { cache, root, tsConfigPaths };
+const parseOptions = { cache, root, tsconfigPaths };
 // these calls use minimal fs
 const fooResult = await parse('src/foo.ts', parseOptions);
 const barResult = await parse('src/bar.ts', parseOptions);
@@ -100,7 +100,7 @@ const barResult = await parse('src/bar.ts', parseOptions);
 
 > Using the root option can lead to errors if there is no tsconfig inside root.
 
-> You are responsible for updating tsConfigPaths if tsconfig files are added/removed on disk during its lifetime.
+> You are responsible for updating tsconfigPaths if tsconfig files are added/removed on disk during its lifetime.
 
 ### error handling
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,7 +19,7 @@ interface TSConfckFindOptions {
      * This is better for performance in projects like vite where find is called frequently but tsconfig locations rarely change
      * You can use `findAll` to build this
      */
-    tsConfigPaths?: Set<string>;
+    tsconfigPaths?: Set<string>;
     /**
      * project root dir, does not continue scanning outside of this directory.
      *

--- a/src/find.ts
+++ b/src/find.ts
@@ -32,8 +32,8 @@ export async function find(filename: string, options?: TSConfckFindOptions) {
 
 async function tsconfigInDir(dir: string, options?: TSConfckFindOptions): Promise<string | void> {
 	const tsconfig = path.join(dir, 'tsconfig.json');
-	if (options?.tsConfigPaths) {
-		return options.tsConfigPaths.has(tsconfig) ? tsconfig : undefined;
+	if (options?.tsconfigPaths) {
+		return options.tsconfigPaths.has(tsconfig) ? tsconfig : undefined;
 	}
 	try {
 		const stat = await fs.stat(tsconfig);
@@ -55,7 +55,7 @@ export interface TSConfckFindOptions {
 	 * This is better for performance in projects like vite where find is called frequently but tsconfig locations rarely change
 	 * You can use `findAll` to build this
 	 */
-	tsConfigPaths?: Set<string>;
+	tsconfigPaths?: Set<string>;
 
 	/**
 	 * project root dir, does not continue scanning outside of this directory.

--- a/tests/find.ts
+++ b/tests/find.ts
@@ -82,7 +82,7 @@ test('should stop searching at root', async () => {
 	}
 });
 
-test('should use provided tsConfigPaths', async () => {
+test('should use provided tsconfigPaths', async () => {
 	const real = path.resolve('tests', 'fixtures', 'find-root', 'tsconfig.json');
 	const fake = path.resolve('tests', 'fixtures', 'find-root', 'a', 'tsconfig.json');
 	const inputs = [
@@ -90,12 +90,12 @@ test('should use provided tsConfigPaths', async () => {
 		path.join('.', 'tests', 'fixtures', 'find-root', 'a', 'b', 'foo.ts'),
 		path.resolve('tests', 'fixtures', 'find-root', 'a', 'b', 'foo.ts')
 	];
-	const tsConfigPaths = new Set<string>([fake]);
+	const tsconfigPaths = new Set<string>([fake]);
 
 	for (const input of inputs) {
 		const tsconfig = await find(input);
 		assert.is(tsconfig, real, `input: ${input}`);
-		const tsconfigWithPaths = await find(input, { tsConfigPaths });
+		const tsconfigWithPaths = await find(input, { tsconfigPaths });
 		assert.is(tsconfigWithPaths, fake, `input: ${input}`);
 	}
 });

--- a/tests/to-json.ts
+++ b/tests/to-json.ts
@@ -24,7 +24,7 @@ test('should throw for invalid tsconfigJson arg', () => {
 		);
 	}
 	// @ts-ignore
-	assert.throws(() => toJson(), TypeError, 'tsConfigJson not set');
+	assert.throws(() => toJson(), TypeError, 'tsconfigJson not set');
 	assert.not.throws(() => toJson('str'));
 });
 


### PR DESCRIPTION
replaces all instances of "tsConfig" with "tsconfig" for naming consistency.

this is a breaking change: `TSConfckFindOptions` key `tsConfigPaths` is now named `tsconfigPaths`.
to migrate: use the renamed key `tsconfigPaths` instead.

none of the package dependents seem to use the option, so the change likely won't be very disruptive (plus migrating is trivial).

resolves #100