### PR TITLE
refactor(cache): introduce standalone cache for find/parse

### DIFF
--- a/.changeset/six-pillows-return.md
+++ b/.changeset/six-pillows-return.md
@@ -1,0 +1,5 @@
+---
+'tsconfck': minor
+---
+
+feat(findNative): add find options (cache, root)

--- a/.changeset/twelve-rings-bow.md
+++ b/.changeset/twelve-rings-bow.md
@@ -1,0 +1,5 @@
+---
+'tsconfck': major
+---
+
+breaking(cache): remove tsconfigPaths option from find, add cache option that lazily caches found tsconfig paths.

--- a/docs/api.md
+++ b/docs/api.md
@@ -272,5 +272,21 @@ export class TSConfckCache {
 	 * clear cache, use this if you have a long running process and tsconfig files have been added,changed or deleted
 	 */
 	clear(): void;
+	/**
+	 * has cached closest tsconfig for files in dir
+	 * */
+	hasTSConfigPath(dir: string): boolean;
+	/**
+	 * get cached closest tsconfig for files in dir
+	 * */
+	getTSConfigPath(dir: string): string;
+	/**
+	 * has parsed tsconfig for file
+	 * */
+	hasParseResult(file: string): boolean;
+	/**
+	 * get parsed tsconfig for file
+	 * */
+	getParseResult(file: string): TSConfckParseResult | TSConfckParseNativeResult;
 }
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -115,7 +115,6 @@ export class TSConfckParseError extends Error {
 	 * absolute path of tsconfig file where the error happened
 	 * */
 	tsconfigFile: string;
-	name: any;
 }
 ```
 
@@ -206,7 +205,6 @@ export class TSConfckParseNativeError extends Error {
 	 * @param result  - parsed result, if any
 	 */
 	constructor(diagnostic: any, tsconfigFile: string, result: any | null);
-	name: any;
 	/**
 	 * code of typescript diagnostic, prefixed with "TS "
 	 * */
@@ -280,7 +278,7 @@ export class TSConfckCache {
 	/**
 	 * get cached closest tsconfig for files in dir
 	 * */
-	getTSConfigPath(dir: string): Promise<string>;
+	getTSConfigPath(dir: string): Awaitable<string | null>;
 	/**
 	 * has parsed tsconfig for file
 	 * */
@@ -288,6 +286,12 @@ export class TSConfckCache {
 	/**
 	 * get parsed tsconfig for file
 	 * */
-	getParseResult(file: string): Promise<TSConfckParseResult | TSConfckParseNativeResult>;
+	getParseResult(file: string): Awaitable<TSConfckParseResult | TSConfckParseNativeResult>;
 }
+```
+
+### Awaitable
+
+```ts
+type Awaitable<T> = Promise<T> | T;
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -270,8 +270,9 @@ export function toJson(tsconfigJson: string): string;
 export class TSConfckCache {
 	/**
 	 * clear cache, use this if you have a long running process and tsconfig files have been added,changed or deleted
+	 * await it to ensure all find and parse calls are settled before continuing
 	 */
-	clear(): void;
+	clear(): Promise<void>;
 	/**
 	 * has cached closest tsconfig for files in dir
 	 * */

--- a/docs/api.md
+++ b/docs/api.md
@@ -279,7 +279,7 @@ export class TSConfckCache {
 	/**
 	 * get cached closest tsconfig for files in dir
 	 * */
-	getTSConfigPath(dir: string): string;
+	getTSConfigPath(dir: string): Promise<string>;
 	/**
 	 * has parsed tsconfig for file
 	 * */

--- a/docs/api.md
+++ b/docs/api.md
@@ -287,6 +287,6 @@ export class TSConfckCache {
 	/**
 	 * get parsed tsconfig for file
 	 * */
-	getParseResult(file: string): TSConfckParseResult | TSConfckParseNativeResult;
+	getParseResult(file: string): Promise<TSConfckParseResult | TSConfckParseNativeResult>;
 }
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,132 +14,7 @@
 export function find(filename: string, options?: TSConfckFindOptions | undefined): Promise<string>;
 ```
 
-### findAll
-
-```ts
-/**
- * find all tsconfig.json files in dir
- *
- * @param dir - path to dir (absolute or relative to cwd)
- * @param options - options
- * @returns list of absolute paths to all found tsconfig.json files
- */
-export function findAll(dir: string, options?: TSConfckFindAllOptions | undefined): Promise<string[]>;
-```
-
-### toJson
-
-```ts
-/**
- * convert content of tsconfig.json to regular json
- *
- * @param tsconfigJson - content of tsconfig.json
- * @returns content as regular json, comments and dangling commas have been replaced with whitespace
- */
-export function toJson(tsconfigJson: string): string;
-```
-
-### findNative
-
-```ts
-/**
- * find the closest tsconfig.json file using native ts.findConfigFile
- *
- * You must have `typescript` installed to use this
- *
- * @param filename - path to file to find tsconfig for (absolute or relative to cwd)
- * @param options - options
- * @returns absolute path to closest tsconfig.json
- */
-export function findNative(filename: string, options?: TSConfckFindOptions | undefined): Promise<string>;
-```
-
-### parse
-
-```ts
-/**
- * parse the closest tsconfig.json file
- *
- * @param filename - path to a tsconfig.json or a .ts source file (absolute or relative to cwd)
- * @param options - options
- * */
-export function parse(filename: string, options?: TSConfckParseOptions | undefined): Promise<TSConfckParseResult>;
-```
-
-### TSConfckParseError
-
-```ts
-export class TSConfckParseError extends Error {
-	/**
-	 *
-	 * @param message - error message
-	 * @param code - error code
-	 * @param tsconfigFile - path to tsconfig file
-	 * @param cause - cause of this error
-	 */
-	constructor(message: string, code: string, tsconfigFile: string, cause: Error | null);
-	/**
-	 * error code
-	 * */
-	code: string;
-	/**
-	 * error cause
-	 * */
-	cause: Error | undefined;
-	/**
-	 * absolute path of tsconfig file where the error happened
-	 * */
-	tsconfigFile: string;
-	name: any;
-}
-```
-
-### parseNative
-
-```ts
-/**
- * parse the closest tsconfig.json file with typescript native functions
- *
- * You need to have `typescript` installed to use this
- *
- * @param filename - path to a tsconfig.json or a .ts source file (absolute or relative to cwd)
- * @param options - options
- * */
-export function parseNative(filename: string, options?: TSConfckParseNativeOptions | undefined): Promise<TSConfckParseNativeResult>;
-```
-
-### TSConfckParseNativeError
-
-```ts
-export class TSConfckParseNativeError extends Error {
-	/**
-	 *
-	 * @param diagnostic - diagnostics of ts
-	 * @param tsconfigFile - file that errored
-	 * @param result  - parsed result, if any
-	 */
-	constructor(diagnostic: any, tsconfigFile: string, result: any | null);
-	name: any;
-	/**
-	 * code of typescript diagnostic, prefixed with "TS "
-	 * */
-	code: string;
-	/**
-	 * full ts diagnostic that caused this error
-	 * */
-	diagnostic: any;
-	/**
-	 * native result if present, contains all errors in result.errors
-	 * */
-	result: any | undefined;
-	/**
-	 * absolute path of tsconfig file where the error happened
-	 * */
-	tsconfigFile: string;
-}
-```
-
-### TSConfckFindOptions
+#### TSConfckFindOptions
 
 ```ts
 interface TSConfckFindOptions {
@@ -159,20 +34,19 @@ interface TSConfckFindOptions {
 }
 ```
 
-### TSConfckFindAllOptions
+### parse
 
 ```ts
-interface TSConfckFindAllOptions {
-	/**
-	 * helper to skip subdirectories when scanning for tsconfig.json
-	 *
-	 * eg ` dir => dir === 'node_modules' || dir === '.git'`
-	 */ // eslint-disable-next-line no-unused-vars
-	skip?: (dir: string) => boolean;
-}
+/**
+ * parse the closest tsconfig.json file
+ *
+ * @param filename - path to a tsconfig.json or a .ts source file (absolute or relative to cwd)
+ * @param options - options
+ * */
+export function parse(filename: string, options?: TSConfckParseOptions | undefined): Promise<TSConfckParseResult>;
 ```
 
-### TSConfckParseOptions
+#### TSConfckParseOptions
 
 ```ts
 interface TSConfckParseOptions extends TSConfckFindOptions {
@@ -184,7 +58,7 @@ interface TSConfckParseOptions extends TSConfckFindOptions {
 }
 ```
 
-### TSConfckParseResult
+#### TSConfckParseResult
 
 ```ts
 interface TSConfckParseResult {
@@ -217,7 +91,64 @@ interface TSConfckParseResult {
 }
 ```
 
-### TSConfckParseNativeOptions
+#### TSConfckParseError
+
+```ts
+export class TSConfckParseError extends Error {
+	/**
+	 *
+	 * @param message - error message
+	 * @param code - error code
+	 * @param tsconfigFile - path to tsconfig file
+	 * @param cause - cause of this error
+	 */
+	constructor(message: string, code: string, tsconfigFile: string, cause: Error | null);
+	/**
+	 * error code
+	 * */
+	code: string;
+	/**
+	 * error cause
+	 * */
+	cause: Error | undefined;
+	/**
+	 * absolute path of tsconfig file where the error happened
+	 * */
+	tsconfigFile: string;
+	name: any;
+}
+```
+
+### findNative
+
+```ts
+/**
+ * find the closest tsconfig.json file using native ts.findConfigFile
+ *
+ * You must have `typescript` installed to use this
+ *
+ * @param filename - path to file to find tsconfig for (absolute or relative to cwd)
+ * @param options - options
+ * @returns absolute path to closest tsconfig.json
+ */
+export function findNative(filename: string, options?: TSConfckFindOptions | undefined): Promise<string>;
+```
+
+### parseNative
+
+```ts
+/**
+ * parse the closest tsconfig.json file with typescript native functions
+ *
+ * You need to have `typescript` installed to use this
+ *
+ * @param filename - path to a tsconfig.json or a .ts source file (absolute or relative to cwd)
+ * @param options - options
+ * */
+export function parseNative(filename: string, options?: TSConfckParseNativeOptions | undefined): Promise<TSConfckParseNativeResult>;
+```
+
+#### TSConfckParseNativeOptions
 
 ```ts
 interface TSConfckParseNativeOptions extends TSConfckParseOptions {
@@ -233,7 +164,7 @@ interface TSConfckParseNativeOptions extends TSConfckParseOptions {
 }
 ```
 
-### TSConfckParseNativeResult
+#### TSConfckParseNativeResult
 
 ```ts
 interface TSConfckParseNativeResult {
@@ -264,26 +195,82 @@ interface TSConfckParseNativeResult {
 }
 ```
 
+#### TSConfckParseNativeError
+
+```ts
+export class TSConfckParseNativeError extends Error {
+	/**
+	 *
+	 * @param diagnostic - diagnostics of ts
+	 * @param tsconfigFile - file that errored
+	 * @param result  - parsed result, if any
+	 */
+	constructor(diagnostic: any, tsconfigFile: string, result: any | null);
+	name: any;
+	/**
+	 * code of typescript diagnostic, prefixed with "TS "
+	 * */
+	code: string;
+	/**
+	 * full ts diagnostic that caused this error
+	 * */
+	diagnostic: any;
+	/**
+	 * native result if present, contains all errors in result.errors
+	 * */
+	result: any | undefined;
+	/**
+	 * absolute path of tsconfig file where the error happened
+	 * */
+	tsconfigFile: string;
+}
+```
+
+### findAll
+
+```ts
+/**
+ * find all tsconfig.json files in dir
+ *
+ * @param dir - path to dir (absolute or relative to cwd)
+ * @param options - options
+ * @returns list of absolute paths to all found tsconfig.json files
+ */
+export function findAll(dir: string, options?: TSConfckFindAllOptions | undefined): Promise<string[]>;
+```
+
+#### TSConfckFindAllOptions
+
+```ts
+interface TSConfckFindAllOptions {
+	/**
+	 * helper to skip subdirectories when scanning for tsconfig.json
+	 *
+	 * eg ` dir => dir === 'node_modules' || dir === '.git'`
+	 */ // eslint-disable-next-line no-unused-vars
+	skip?: (dir: string) => boolean;
+}
+```
+
+### toJson
+
+```ts
+/**
+ * convert content of tsconfig.json to regular json
+ *
+ * @param tsconfigJson - content of tsconfig.json
+ * @returns content as regular json, comments and dangling commas have been replaced with whitespace
+ */
+export function toJson(tsconfigJson: string): string;
+```
+
 ### TSConfckCache
 
 ```ts
-class TSConfckCache {
+export class TSConfckCache {
 	/**
 	 * clear cache, use this if you have a long running process and tsconfig files have been added,changed or deleted
 	 */
 	clear(): void;
-	
-	setTSConfigPath(tsconfigPath: string, directories: string[]): void;
-	
-	getTSConfigPath(dir: string): string;
-	
-	hasTSConfigPath(dir: string): boolean;
-	
-	getParseResult(file: string): TSConfckParseResult | TSConfckParseNativeResult;
-	
-	setParseResult(file: any, result: TSConfckParseResult | TSConfckParseNativeResult): void;
-	
-	hasParseResult(file: string): boolean;
-	#private;
 }
 ```

--- a/package.json
+++ b/package.json
@@ -21,17 +21,17 @@
 	"devDependencies": {
 		"@changesets/cli": "^2.26.2",
 		"@svitejs/changesets-changelog-github-compact": "^1.1.0",
-		"dts-buddy": "^0.1.12",
-		"eslint": "^8.46.0",
-		"eslint-config-prettier": "^8.10.0",
+		"dts-buddy": "^0.2.4",
+		"eslint": "^8.48.0",
+		"eslint-config-prettier": "^9.0.0",
 		"eslint-plugin-markdown": "^3.0.1",
-		"eslint-plugin-n": "^16.0.1",
+		"eslint-plugin-n": "^16.0.2",
 		"eslint-plugin-prettier": "^5.0.0",
-		"lint-staged": "^14.0.0",
+		"lint-staged": "^14.0.1",
 		"npm-run-all": "^4.1.5",
-		"prettier": "^3.0.1",
-		"publint": "^0.2.0",
-		"vitest": "^0.34.1"
+		"prettier": "^3.0.3",
+		"publint": "^0.2.2",
+		"vitest": "^0.34.3"
 	},
 	"lint-staged": {
 		"*.{js,md}": "eslint --cache --fix",

--- a/packages/tsconfck/README.md
+++ b/packages/tsconfck/README.md
@@ -69,28 +69,30 @@ import { find, parse, TSCOnfckCache } from 'tsconfck';
 // 1. create cache instance
 const cache = new TSCOnfckCache();
 // 2. pass cache instance in options
-const fooTSConfig = await find(('src/foo.ts', { cache })); // stores tsconfit for src in cache
-const barTSConfig = await find(('src/bar.ts', { cache })); // reuses tsconfig result for src
+const fooTSConfig = await find(('src/foo.ts', { cache })); // stores tsconfig for src in cache
+const barTSConfig = await find(('src/bar.ts', { cache })); // reuses tsconfig result for src without fs call
 
 const fooResult = await parse('src/foo.ts', { cache }); // uses cached path for tsconfig, stores parse result in cache
-const barResult = await parse('src/bar.ts', { cache }); // uses cached parse result
+const barResult = await parse('src/bar.ts', { cache }); // uses cached parse result without fs call or resolving
 ```
 
 #### cache invalidation
 
-You are responsible for clearing the cache if tsconfig files are added/removed/changed during the cache lifetime.
+You are responsible for clearing the cache if tsconfig files are added/removed/changed after reading them during the cache lifetime.
 
-Call `cache.clear()` and also omit all previous compilation results based on cached configs.
+Call `cache.clear()` and also discard all previous compilation results based previously cached configs.
 
 #### cache mutation
 
-Returned results are direct cache objects. If you want to modify them, deep-clone first
+Returned results are direct cache objects. If you want to modify them, deep-clone first.
 
 #### cache reuse
 
-Never use the same cache instance for mixed calls of parse/parseNative as result structures are different
+Never use the same cache instance for mixed calls of find/findNative or parse/parseNative as result structures are different
 
 ### root
+
+This option can be used to limit finding tsconfig files outside of a root directory
 
 ```js
 import { parse, TSConfckCache } from 'tsconfck';

--- a/packages/tsconfck/package.json
+++ b/packages/tsconfck/package.json
@@ -44,11 +44,11 @@
 		}
 	},
 	"devDependencies": {
-		"@tsconfig/node18": "^18.2.0",
-		"esbuild": "^0.19.1",
+		"@tsconfig/node18": "^18.2.1",
+		"esbuild": "^0.19.2",
 		"tiny-glob": "^0.2.9",
-		"typescript": "^5.1.6",
-		"vitest": "^0.34.1"
+		"typescript": "^5.2.2",
+		"vitest": "^0.34.3"
 	},
 	"engines": {
 		"node": "^18 || >=20"

--- a/packages/tsconfck/src/cache.js
+++ b/packages/tsconfck/src/cache.js
@@ -1,14 +1,16 @@
 export class TSConfckCache {
 	/**
-	 * @internal
 	 * map directories to their closest tsconfig.json
+	 * @internal
+	 * @private
 	 * @type{Map<string,string>}
 	 */
 	#tsconfigPaths = new Map();
 
 	/**
-	 * @internal
 	 * map files to their parsed tsconfig result
+	 * @internal
+	 * @private
 	 * @type {Map<string,import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult>}
 	 */
 	#parsed = new Map();
@@ -23,6 +25,7 @@ export class TSConfckCache {
 
 	/**
 	 * @internal
+	 * @private
 	 * @param {string} tsconfigPath
 	 * @param {string[]} directories
 	 */
@@ -34,6 +37,7 @@ export class TSConfckCache {
 
 	/**
 	 * @internal
+	 * @private
 	 * @param {string} dir
 	 * @returns {string}
 	 */
@@ -43,6 +47,7 @@ export class TSConfckCache {
 
 	/**
 	 * @internal
+	 * @private
 	 * @param {string} dir
 	 * @returns {boolean}
 	 */
@@ -52,6 +57,7 @@ export class TSConfckCache {
 
 	/**
 	 * @internal
+	 * @private
 	 * @param {string} file
 	 * @returns {import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult }
 	 */
@@ -61,6 +67,7 @@ export class TSConfckCache {
 
 	/**
 	 * @internal
+	 * @private
 	 * @param file
 	 * @param {import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult} result
 	 */
@@ -70,6 +77,7 @@ export class TSConfckCache {
 
 	/**
 	 * @internal
+	 * @private
 	 * @param {string} file
 	 * @returns {boolean}
 	 */

--- a/packages/tsconfck/src/cache.js
+++ b/packages/tsconfck/src/cache.js
@@ -19,9 +19,9 @@ export class TSConfckCache {
 	/**
 	 * get cached closest tsconfig for files in dir
 	 * @param {string} dir
-	 * @returns {string}
+	 * @returns {Promise<string>}
 	 */
-	getTSConfigPath(dir) {
+	async getTSConfigPath(dir) {
 		return this.#tsconfigPaths.get(dir);
 	}
 
@@ -56,20 +56,18 @@ export class TSConfckCache {
 	/**
 	 * @internal
 	 * @private
-	 * @param {string} tsconfigPath
-	 * @param {string[]} directories
+	 * @param {string} dir
+	 * @param {Promise<string>} tsconfigPath
 	 */
-	setTSConfigPath(tsconfigPath, directories) {
-		for (const dir of directories) {
-			this.#tsconfigPaths.set(dir, tsconfigPath);
-		}
+	setTSConfigPath(dir, tsconfigPath) {
+		this.#tsconfigPaths.set(dir, tsconfigPath);
 	}
 
 	/**
 	 * map directories to their closest tsconfig.json
 	 * @internal
 	 * @private
-	 * @type{Map<string,string>}
+	 * @type{Map<string,Promise<string>>}
 	 */
 	#tsconfigPaths = new Map();
 

--- a/packages/tsconfck/src/cache.js
+++ b/packages/tsconfck/src/cache.js
@@ -37,7 +37,7 @@ export class TSConfckCache {
 	/**
 	 * get parsed tsconfig for file
 	 * @param {string} file
-	 * @returns {import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult }
+	 * @returns {Promise<import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult> }
 	 */
 	getParseResult(file) {
 		return this.#parsed.get(file);
@@ -47,10 +47,19 @@ export class TSConfckCache {
 	 * @internal
 	 * @private
 	 * @param file
-	 * @param {import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult} result
+	 * @param {Promise<import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult> } result
 	 */
 	setParseResult(file, result) {
 		this.#parsed.set(file, result);
+	}
+
+	/**
+	 * @internal
+	 * @private
+	 * @param file
+	 */
+	deleteParseResult(file) {
+		this.#parsed.delete(file);
 	}
 
 	/**
@@ -75,7 +84,7 @@ export class TSConfckCache {
 	 * map files to their parsed tsconfig result
 	 * @internal
 	 * @private
-	 * @type {Map<string,import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult>}
+	 * @type {Map<string,Promise<import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult>>}
 	 */
 	#parsed = new Map();
 }

--- a/packages/tsconfck/src/cache.js
+++ b/packages/tsconfck/src/cache.js
@@ -1,0 +1,79 @@
+export class TSConfckCache {
+	/**
+	 * @internal
+	 * map directories to their closest tsconfig.json
+	 * @type{Map<string,string>}
+	 */
+	#tsconfigPaths = new Map();
+
+	/**
+	 * @internal
+	 * map files to their parsed tsconfig result
+	 * @type {Map<string,import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult>}
+	 */
+	#parsed = new Map();
+
+	/**
+	 * clear cache, use this if you have a long running process and tsconfig files have been added,changed or deleted
+	 */
+	clear() {
+		this.#tsconfigPaths.clear();
+		this.#parsed.clear();
+	}
+
+	/**
+	 * @internal
+	 * @param {string} tsconfigPath
+	 * @param {string[]} directories
+	 */
+	setTSConfigPath(tsconfigPath, directories) {
+		for (const dir of directories) {
+			this.#tsconfigPaths.set(dir, tsconfigPath);
+		}
+	}
+
+	/**
+	 * @internal
+	 * @param {string} dir
+	 * @returns {string}
+	 */
+	getTSConfigPath(dir) {
+		return this.#tsconfigPaths.get(dir);
+	}
+
+	/**
+	 * @internal
+	 * @param {string} dir
+	 * @returns {boolean}
+	 */
+	hasTSConfigPath(dir) {
+		return this.#tsconfigPaths.has(dir);
+	}
+
+	/**
+	 * @internal
+	 * @param {string} file
+	 * @returns {import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult }
+	 */
+	getParseResult(file) {
+		return this.#parsed.get(file);
+	}
+
+	/**
+	 * @internal
+	 * @param file
+	 * @param {import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult} result
+	 */
+	setParseResult(file, result) {
+		this.#parsed.set(file, result);
+	}
+
+	/**
+	 * @internal
+	 * @param {string} file
+	 * @returns {boolean}
+	 */
+	hasParseResult(file) {
+		return this.#parsed.has(file);
+	}
+}

--- a/packages/tsconfck/src/cache.js
+++ b/packages/tsconfck/src/cache.js
@@ -1,21 +1,5 @@
 export class TSConfckCache {
 	/**
-	 * map directories to their closest tsconfig.json
-	 * @internal
-	 * @private
-	 * @type{Map<string,string>}
-	 */
-	#tsconfigPaths = new Map();
-
-	/**
-	 * map files to their parsed tsconfig result
-	 * @internal
-	 * @private
-	 * @type {Map<string,import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult>}
-	 */
-	#parsed = new Map();
-
-	/**
 	 * clear cache, use this if you have a long running process and tsconfig files have been added,changed or deleted
 	 */
 	clear() {
@@ -24,30 +8,7 @@ export class TSConfckCache {
 	}
 
 	/**
-	 * @internal
-	 * @private
-	 * @param {string} tsconfigPath
-	 * @param {string[]} directories
-	 */
-	setTSConfigPath(tsconfigPath, directories) {
-		for (const dir of directories) {
-			this.#tsconfigPaths.set(dir, tsconfigPath);
-		}
-	}
-
-	/**
-	 * @internal
-	 * @private
-	 * @param {string} dir
-	 * @returns {string}
-	 */
-	getTSConfigPath(dir) {
-		return this.#tsconfigPaths.get(dir);
-	}
-
-	/**
-	 * @internal
-	 * @private
+	 * has cached closest tsconfig for files in dir
 	 * @param {string} dir
 	 * @returns {boolean}
 	 */
@@ -56,8 +17,25 @@ export class TSConfckCache {
 	}
 
 	/**
-	 * @internal
-	 * @private
+	 * get cached closest tsconfig for files in dir
+	 * @param {string} dir
+	 * @returns {string}
+	 */
+	getTSConfigPath(dir) {
+		return this.#tsconfigPaths.get(dir);
+	}
+
+	/**
+	 * has parsed tsconfig for file
+	 * @param {string} file
+	 * @returns {boolean}
+	 */
+	hasParseResult(file) {
+		return this.#parsed.has(file);
+	}
+
+	/**
+	 * get parsed tsconfig for file
 	 * @param {string} file
 	 * @returns {import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult }
 	 */
@@ -78,10 +56,28 @@ export class TSConfckCache {
 	/**
 	 * @internal
 	 * @private
-	 * @param {string} file
-	 * @returns {boolean}
+	 * @param {string} tsconfigPath
+	 * @param {string[]} directories
 	 */
-	hasParseResult(file) {
-		return this.#parsed.has(file);
+	setTSConfigPath(tsconfigPath, directories) {
+		for (const dir of directories) {
+			this.#tsconfigPaths.set(dir, tsconfigPath);
+		}
 	}
+
+	/**
+	 * map directories to their closest tsconfig.json
+	 * @internal
+	 * @private
+	 * @type{Map<string,string>}
+	 */
+	#tsconfigPaths = new Map();
+
+	/**
+	 * map files to their parsed tsconfig result
+	 * @internal
+	 * @private
+	 * @type {Map<string,import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult>}
+	 */
+	#parsed = new Map();
 }

--- a/packages/tsconfck/src/cache.js
+++ b/packages/tsconfck/src/cache.js
@@ -1,6 +1,4 @@
 export class TSConfckCache {
-	/** @typedef {Promise<T>|T} Awaitable<T> */
-
 	/**
 	 * clear cache, use this if you have a long running process and tsconfig files have been added,changed or deleted
 	 * await it to ensure all find and parse calls are settled before continuing
@@ -10,11 +8,14 @@ export class TSConfckCache {
 			this.#clearing = Promise.allSettled([
 				...this.#tsconfigPaths.values(),
 				...this.#parsed.values()
-			]).then(() => {
-				this.#tsconfigPaths.clear();
-				this.#parsed.clear();
-				this.#clearing = undefined;
-			});
+			])
+				.then(() => {
+					this.#tsconfigPaths.clear();
+					this.#parsed.clear();
+				})
+				.finally(() => {
+					this.#clearing = undefined;
+				});
 		}
 		return this.#clearing;
 	}
@@ -31,7 +32,7 @@ export class TSConfckCache {
 	/**
 	 * get cached closest tsconfig for files in dir
 	 * @param {string} dir
-	 * @returns {Awaitable<string|null>}
+	 * @returns {import('./public.d.ts').Awaitable<string|null>}
 	 */
 	async getTSConfigPath(dir) {
 		return this.#tsconfigPaths.get(dir);
@@ -49,7 +50,7 @@ export class TSConfckCache {
 	/**
 	 * get parsed tsconfig for file
 	 * @param {string} file
-	 * @returns {Awaitable<import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult>}
+	 * @returns {import('./public.d.ts').Awaitable<import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult>}
 	 */
 	getParseResult(file) {
 		return this.#parsed.get(file);
@@ -92,7 +93,7 @@ export class TSConfckCache {
 	 * map directories to their closest tsconfig.json
 	 * @internal
 	 * @private
-	 * @type{Map<string,Awaitable<string|null>>}
+	 * @type{Map<string,import('./public.d.ts').Awaitable<string|null>>}
 	 */
 	#tsconfigPaths = new Map();
 
@@ -100,7 +101,7 @@ export class TSConfckCache {
 	 * map files to their parsed tsconfig result
 	 * @internal
 	 * @private
-	 * @type {Map<string,Awaitable<import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult>> }
+	 * @type {Map<string,import('./public.d.ts').Awaitable<import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult>> }
 	 */
 	#parsed = new Map();
 

--- a/packages/tsconfck/src/find-native.js
+++ b/packages/tsconfck/src/find-native.js
@@ -15,7 +15,7 @@ export async function findNative(filename, options) {
 	const cache = options?.cache;
 	const root = options?.root ? path.resolve(options.root) : undefined;
 	if (cache?.hasTSConfigPath(fileDir)) {
-		const tsconfigFile = cache.getTSConfigPath(fileDir);
+		const tsconfigFile = await cache.getTSConfigPath(fileDir);
 		if (!tsconfigFile) {
 			throw new Error(`no tsconfig file found for ${filename}`);
 		}
@@ -66,5 +66,8 @@ function cache_result(tsconfigFile, fileDir, cache, root) {
 			dir = parent;
 		}
 	}
-	cache.setTSConfigPath(tsconfigFile, directories);
+	const p = Promise.resolve(tsconfigFile);
+	directories.forEach((d) => {
+		cache.setTSConfigPath(d, p);
+	});
 }

--- a/packages/tsconfck/src/find-native.js
+++ b/packages/tsconfck/src/find-native.js
@@ -7,14 +7,64 @@ import { loadTS } from './util.js';
  * You must have `typescript` installed to use this
  *
  * @param {string} filename - path to file to find tsconfig for (absolute or relative to cwd)
+ * @param {import('./public.d.ts').TSConfckFindOptions} [options] - options
  * @returns {Promise<string>} absolute path to closest tsconfig.json
  */
-export async function findNative(filename) {
+export async function findNative(filename, options) {
+	const fileDir = path.dirname(path.resolve(filename));
+	const cache = options?.cache;
+	const root = options?.root ? path.resolve(options.root) : undefined;
+	if (cache?.hasTSConfigPath(fileDir)) {
+		const tsconfigFile = cache.getTSConfigPath(fileDir);
+		if (!tsconfigFile) {
+			throw new Error(`no tsconfig file found for ${filename}`);
+		}
+		return tsconfigFile;
+	}
 	const ts = await loadTS();
 	const { findConfigFile, sys } = ts;
-	const tsconfigFile = findConfigFile(path.dirname(path.resolve(filename)), sys.fileExists);
+	let tsconfigFile = findConfigFile(fileDir, sys.fileExists);
+	if (is_out_of_root(tsconfigFile, root)) {
+		tsconfigFile = null;
+	}
+	if (cache) {
+		cache_result(tsconfigFile, fileDir, cache, root);
+	}
 	if (!tsconfigFile) {
 		throw new Error(`no tsconfig file found for ${filename}`);
 	}
 	return tsconfigFile;
+}
+
+/**
+ *
+ * @param {string} tsconfigFile
+ * @param {string} root
+ */
+function is_out_of_root(tsconfigFile, root) {
+	return root && !tsconfigFile.startsWith(root);
+}
+
+/**
+ * add all intermediate directories between fileDir and tsconfigFile to cache
+ * if no tsconfig was found, go up until root
+ * @param {string} tsconfigFile
+ * @param {string} fileDir
+ * @param {TSConfckCache} cache
+ * @param {string} [root]
+ */
+function cache_result(tsconfigFile, fileDir, cache, root) {
+	const tsconfigDir = tsconfigFile ? path.dirname(tsconfigFile) : root;
+	const directories = [];
+	let dir = fileDir;
+	while (dir) {
+		directories.push(dir);
+		const parent = path.dirname(dir);
+		if (tsconfigDir === dir || parent === dir) {
+			break;
+		} else {
+			dir = parent;
+		}
+	}
+	cache.setTSConfigPath(tsconfigFile, directories);
 }

--- a/packages/tsconfck/src/find.js
+++ b/packages/tsconfck/src/find.js
@@ -25,7 +25,12 @@ export async function find(filename, options) {
 	while (dir) {
 		if (cache) {
 			if (cache.hasTSConfigPath(dir)) {
-				cache.getTSConfigPath(dir).then(resolvePathPromise);
+				const cached = cache.getTSConfigPath(dir);
+				if (cached.then) {
+					cached.then(resolvePathPromise);
+				} else {
+					resolvePathPromise(/**@type {string|null} */ (cached));
+				}
 				return pathPromise;
 			} else {
 				cache.setTSConfigPath(dir, pathPromise);

--- a/packages/tsconfck/src/index.js
+++ b/packages/tsconfck/src/index.js
@@ -4,3 +4,4 @@ export { toJson } from './to-json.js';
 export { parse, TSConfckParseError } from './parse.js';
 export { findNative } from './find-native.js';
 export { parseNative, TSConfckParseNativeError } from './parse-native.js';
+export { TSConfckCache } from './cache.js';

--- a/packages/tsconfck/src/parse-native.js
+++ b/packages/tsconfck/src/parse-native.js
@@ -37,7 +37,7 @@ export async function parseNative(filename, options) {
 				tsconfig: {},
 				result: null
 			};
-			cache?.setParseResult(filename, notFoundResult);
+			cache?.setParseResult(filename, Promise.resolve(notFoundResult));
 			return notFoundResult;
 		}
 	} else {
@@ -55,13 +55,13 @@ export async function parseNative(filename, options) {
 		const ts = await loadTS();
 		result = await parseFile(tsconfigFile, ts, options);
 		await parseReferences(result, ts, options);
-		cache?.setParseResult(tsconfigFile, result);
+		cache?.setParseResult(tsconfigFile, Promise.resolve(result));
 	}
 
 	//@ts-ignore
 	result = resolveSolutionTSConfig(filename, result);
 	//@ts-ignore
-	cache?.setParseResult(filename, result);
+	cache?.setParseResult(filename, Promise.resolve(result));
 	return result;
 }
 
@@ -110,7 +110,7 @@ async function parseFile(tsconfigFile, ts, options) {
 		tsconfig: result2tsconfig(nativeResult, ts),
 		result: nativeResult
 	};
-	cache?.setParseResult(tsconfigFile, result);
+	cache?.setParseResult(tsconfigFile, Promise.resolve(result));
 	return result;
 }
 

--- a/packages/tsconfck/src/parse-native.js
+++ b/packages/tsconfck/src/parse-native.js
@@ -20,8 +20,8 @@ import { findNative } from './find-native.js';
  */
 export async function parseNative(filename, options) {
 	const cache = options?.cache;
-	if (cache?.has(filename)) {
-		return cache.get(filename);
+	if (cache?.hasParseResult(filename)) {
+		return cache.getParseResult(filename);
 	}
 	let tsconfigFile;
 
@@ -37,7 +37,7 @@ export async function parseNative(filename, options) {
 				tsconfig: {},
 				result: null
 			};
-			cache?.set(filename, notFoundResult);
+			cache?.setParseResult(filename, notFoundResult);
 			return notFoundResult;
 		}
 	} else {
@@ -49,19 +49,19 @@ export async function parseNative(filename, options) {
 
 	/** @type {import('./public.d.ts').TSConfckParseNativeResult} */
 	let result;
-	if (cache?.has(tsconfigFile)) {
-		result = cache.get(tsconfigFile);
+	if (cache?.hasParseResult(tsconfigFile)) {
+		result = cache.getParseResult(tsconfigFile);
 	} else {
 		const ts = await loadTS();
 		result = await parseFile(tsconfigFile, ts, options);
 		await parseReferences(result, ts, options);
-		cache?.set(tsconfigFile, result);
+		cache?.setParseResult(tsconfigFile, result);
 	}
 
 	//@ts-ignore
 	result = resolveSolutionTSConfig(filename, result);
 	//@ts-ignore
-	cache?.set(filename, result);
+	cache?.setParseResult(filename, result);
 	return result;
 }
 
@@ -74,8 +74,8 @@ export async function parseNative(filename, options) {
  */
 async function parseFile(tsconfigFile, ts, options) {
 	const cache = options?.cache;
-	if (cache?.has(tsconfigFile)) {
-		return cache.get(tsconfigFile);
+	if (cache?.hasParseResult(tsconfigFile)) {
+		return cache.getParseResult(tsconfigFile);
 	}
 	const posixTSConfigFile = native2posix(tsconfigFile);
 	const { parseJsonConfigFileContent, readConfigFile, sys } = ts;
@@ -110,7 +110,7 @@ async function parseFile(tsconfigFile, ts, options) {
 		tsconfig: result2tsconfig(nativeResult, ts),
 		result: nativeResult
 	};
-	cache?.set(tsconfigFile, result);
+	cache?.setParseResult(tsconfigFile, result);
 	return result;
 }
 

--- a/packages/tsconfck/src/parse.js
+++ b/packages/tsconfck/src/parse.js
@@ -79,7 +79,6 @@ async function parseFile(tsconfigFile, cache, skipCache) {
 			};
 		})
 		.catch((e) => {
-			cache?.deleteParseResult(tsconfigFile);
 			throw new TSConfckParseError(
 				`parsing ${tsconfigFile} failed: ${e}`,
 				'PARSE_FILE',
@@ -110,7 +109,7 @@ function normalizeTSConfig(tsconfig, dir) {
 /**
  *
  * @param {import('./public.d.ts').TSConfckParseResult} result
- * @param {Map<string, import('./public.d.ts').TSConfckParseResult>?} cache
+ * @param {TSConfckCache} [cache]
  * @returns {Promise<void>}
  */
 async function parseReferences(result, cache) {
@@ -125,7 +124,7 @@ async function parseReferences(result, cache) {
 
 /**
  * @param {import('./public.d.ts').TSConfckParseResult} result
- * @param {Map<string, import('./public.d.ts').TSConfckParseResult>?} cache
+ * @param {TSConfckCache} [cache]
  * @returns {Promise<void>}
  */
 async function parseExtends(result, cache) {

--- a/packages/tsconfck/src/public.d.ts
+++ b/packages/tsconfck/src/public.d.ts
@@ -1,11 +1,12 @@
+import { TSConfckCache } from './cache';
+
 export interface TSConfckFindOptions {
 	/**
-	 * Set of known tsconfig file locations to use instead of scanning the file system
+	 * A cache to improve performance for multiple calls in the same project
 	 *
-	 * This is better for performance in projects like vite where find is called frequently but tsconfig locations rarely change
-	 * You can use `findAll` to build this
+	 * Warning: You must clear this cache in case tsconfig files are added/removed during it's lifetime
 	 */
-	tsconfigPaths?: Set<string>;
+	cache?: TSConfckCache;
 
 	/**
 	 * project root dir, does not continue scanning outside of this directory.
@@ -25,15 +26,6 @@ export interface TSConfckFindAllOptions {
 }
 
 export interface TSConfckParseOptions extends TSConfckFindOptions {
-	/**
-	 * optional cache map to speed up repeated parsing with multiple files
-	 * it is your own responsibility to clear the cache if tsconfig files change during its lifetime
-	 * cache keys are input `filename` and absolute paths to tsconfig.json files
-	 *
-	 * You must not modify cached values.
-	 */
-	cache?: Map<string, TSConfckParseResult>;
-
 	/**
 	 * treat missing tsconfig as empty result instead of an error
 	 * parse resolves with { filename: 'no_tsconfig_file_found',tsconfig:{}} instead of reject with error
@@ -70,22 +62,7 @@ export interface TSConfckParseResult {
 	extended?: TSConfckParseResult[];
 }
 
-export interface TSConfckParseNativeOptions {
-	/**
-	 * optional cache map to speed up repeated parsing with multiple files
-	 * it is your own responsibility to clear the cache if tsconfig files change during its lifetime
-	 * cache keys are input `filename` and absolute paths to tsconfig.json files
-	 *
-	 * You must not modify cached values.
-	 */
-	cache?: Map<string, TSConfckParseNativeResult>;
-
-	/**
-	 * treat missing tsconfig as empty result instead of an error
-	 * parseNative resolves with { filename: 'no_tsconfig_file_found',tsconfig:{}, result: null} instead of reject with error
-	 */
-	resolveWithEmptyIfConfigNotFound?: boolean;
-
+export interface TSConfckParseNativeOptions extends TSConfckParseOptions {
 	/**
 	 * Set this option to true to force typescript to ignore all source files.
 	 *

--- a/packages/tsconfck/src/public.d.ts
+++ b/packages/tsconfck/src/public.d.ts
@@ -100,3 +100,5 @@ export interface TSConfckParseNativeResult {
 	 */
 	result: any;
 }
+
+export type Awaitable<T> = Promise<T> | T;

--- a/packages/tsconfck/tests/cache.js
+++ b/packages/tsconfck/tests/cache.js
@@ -7,21 +7,12 @@ describe('cache', () => {
 	beforeEach(() => {
 		cache = new TSConfckCache();
 	});
-	describe('setTSConfigPath', () => {
-		it('should add entries for every directory', () => {
-			expect(cache.hasTSConfigPath('bar')).toBe(false);
-			expect(cache.hasTSConfigPath('baz')).toBe(false);
-			cache.setTSConfigPath('foo', ['bar', 'baz']);
-			expect(cache.hasTSConfigPath('bar')).toBe(true);
-			expect(cache.hasTSConfigPath('baz')).toBe(true);
-		});
-	});
 	describe('clear', () => {
 		it('should remove all data', () => {
 			const result = /**@type TSConfckParseResult */ ({});
 			expect(cache.hasParseResult('file')).toBe(false);
 			cache.setParseResult('file', result);
-			cache.setTSConfigPath('foo', ['bar']);
+			cache.setTSConfigPath('bar', Promise.resolve('bar'));
 			expect(cache.hasParseResult('file')).toBe(true);
 			expect(cache.hasTSConfigPath('bar')).toBe(true);
 			cache.clear();

--- a/packages/tsconfck/tests/cache.js
+++ b/packages/tsconfck/tests/cache.js
@@ -9,6 +9,8 @@ describe('cache', () => {
 	});
 	describe('setTSConfigPath', () => {
 		it('should add entries for every directory', () => {
+			expect(cache.hasTSConfigPath('bar')).toBe(false);
+			expect(cache.hasTSConfigPath('baz')).toBe(false);
 			cache.setTSConfigPath('foo', ['bar', 'baz']);
 			expect(cache.hasTSConfigPath('bar')).toBe(true);
 			expect(cache.hasTSConfigPath('baz')).toBe(true);
@@ -17,6 +19,7 @@ describe('cache', () => {
 	describe('clear', () => {
 		it('should remove all data', () => {
 			const result = /**@type TSConfckParseResult */ ({});
+			expect(cache.hasParseResult('file')).toBe(false);
 			cache.setParseResult('file', result);
 			cache.setTSConfigPath('foo', ['bar']);
 			expect(cache.hasParseResult('file')).toBe(true);

--- a/packages/tsconfck/tests/cache.js
+++ b/packages/tsconfck/tests/cache.js
@@ -1,0 +1,29 @@
+import { beforeEach, describe, it, expect } from 'vitest';
+import { TSConfckCache } from '../src/cache.js';
+
+describe('cache', () => {
+	/** @type TSConfckCache */
+	let cache;
+	beforeEach(() => {
+		cache = new TSConfckCache();
+	});
+	describe('setTSConfigPath', () => {
+		it('should add entries for every directory', () => {
+			cache.setTSConfigPath('foo', ['bar', 'baz']);
+			expect(cache.hasTSConfigPath('bar')).toBe(true);
+			expect(cache.hasTSConfigPath('baz')).toBe(true);
+		});
+	});
+	describe('clear', () => {
+		it('should remove all data', () => {
+			const result = /**@type TSConfckParseResult */ ({});
+			cache.setParseResult('file', result);
+			cache.setTSConfigPath('foo', ['bar']);
+			expect(cache.hasParseResult('file')).toBe(true);
+			expect(cache.hasTSConfigPath('bar')).toBe(true);
+			cache.clear();
+			expect(cache.hasParseResult('file')).toBe(false);
+			expect(cache.hasTSConfigPath('bar')).toBe(false);
+		});
+	});
+});

--- a/packages/tsconfck/tests/cache.js
+++ b/packages/tsconfck/tests/cache.js
@@ -8,16 +8,39 @@ describe('cache', () => {
 		cache = new TSConfckCache();
 	});
 	describe('clear', () => {
-		it('should remove all data', () => {
-			const result = /**@type TSConfckParseResult */ ({});
+		it('should remove all data', async () => {
+			const result = Promise.resolve(/**@type TSConfckParseResult */ ({}));
 			expect(cache.hasParseResult('file')).toBe(false);
 			cache.setParseResult('file', result);
 			cache.setTSConfigPath('bar', Promise.resolve('bar'));
 			expect(cache.hasParseResult('file')).toBe(true);
 			expect(cache.hasTSConfigPath('bar')).toBe(true);
-			cache.clear();
+			await cache.clear();
 			expect(cache.hasParseResult('file')).toBe(false);
 			expect(cache.hasTSConfigPath('bar')).toBe(false);
 		});
+
+		it.fails(
+			'to settle with pending parse result',
+			async () => {
+				const resultPromise = new Promise(() => {});
+				expect(cache.hasParseResult('file')).toBe(false);
+				cache.setParseResult('file', resultPromise);
+				expect(cache.hasParseResult('file')).toBe(true);
+				await cache.clear();
+			},
+			50
+		);
+		it.fails(
+			'to settle with pending find result',
+			async () => {
+				const resultPromise = new Promise(() => {});
+				expect(cache.hasTSConfigPath('file')).toBe(false);
+				cache.setTSConfigPath('file', resultPromise);
+				expect(cache.hasTSConfigPath('file')).toBe(true);
+				await cache.clear();
+			},
+			50
+		);
 	});
 });

--- a/packages/tsconfck/tests/find-native.js
+++ b/packages/tsconfck/tests/find-native.js
@@ -73,14 +73,16 @@ describe('find-native', () => {
 		}
 		const dir = path.dirname(absoluteTS);
 		expect(cache.hasTSConfigPath(dir)).toBe(true);
-		expect(cache.getTSConfigPath(dir)).toBe(expected);
+		expect(await cache.getTSConfigPath(dir)).toBe(expected);
 		const parent = path.dirname(dir);
 		expect(cache.hasTSConfigPath(parent)).toBe(true);
-		expect(cache.getTSConfigPath(parent)).toBe(expected);
+		expect(await cache.getTSConfigPath(parent)).toBe(expected);
 		const root = path.dirname(real);
 		expect(cache.hasTSConfigPath(root)).toBe(true);
-		expect(cache.getTSConfigPath(root)).toBe(expected);
-		cache.setTSConfigPath('fake', [dir, parent, root]);
+		expect(await cache.getTSConfigPath(root)).toBe(expected);
+		[dir, parent, root].forEach((d) => {
+			cache.setTSConfigPath(d, Promise.resolve('fake'));
+		});
 		for (const input of inputs) {
 			expect(await findNative(input, { cache }), `input: ${input}`).toBe('fake');
 		}

--- a/packages/tsconfck/tests/find-native.js
+++ b/packages/tsconfck/tests/find-native.js
@@ -4,6 +4,7 @@ import os from 'os';
 import { findNative } from '../src/find-native.js';
 import { absFixture, absRoot, relFixture } from './util/fixture-paths.js';
 import { native2posix } from '../src/util.js';
+import { TSConfckCache } from '../src/cache.js';
 
 describe('find-native', () => {
 	it('should be a function', () => {
@@ -43,6 +44,44 @@ describe('find-native', () => {
 		const inputs = [relativeTS, `./${relativeTS}`, absoluteTS];
 		for (const input of inputs) {
 			expect(await findNative(input), `input: ${input}`).toBe(expected);
+		}
+	});
+
+	it('should stop searching at root', async () => {
+		const fixtureDir = 'find-root/a';
+		const relativeTS = relFixture(`${fixtureDir}/b/foo.ts`);
+		const absoluteTS = absFixture(`${fixtureDir}/b/foo.ts`);
+		const inputs = [relativeTS, `./${relativeTS}`, absoluteTS];
+
+		for (const input of inputs) {
+			await expect(findNative(input, { root: absFixture(fixtureDir) })).rejects.toThrow(
+				'no tsconfig file found for ' + input
+			);
+		}
+	});
+
+	it('should use provided cache', async () => {
+		const fixtureDir = 'find-root';
+		const relativeTS = relFixture(`${fixtureDir}/a/b/foo.ts`);
+		const absoluteTS = absFixture(`${fixtureDir}/a/b/foo.ts`);
+		const inputs = [relativeTS, `./${relativeTS}`, absoluteTS];
+		const real = absFixture(`${fixtureDir}/tsconfig.json`);
+		const cache = new TSConfckCache();
+		for (const input of inputs) {
+			expect(await findNative(input, { cache }), `input: ${input}`).toBe(real);
+		}
+		const dir = path.dirname(absoluteTS);
+		expect(cache.hasTSConfigPath(dir)).toBe(true);
+		expect(cache.getTSConfigPath(dir)).toBe(real);
+		const parent = path.dirname(dir);
+		expect(cache.hasTSConfigPath(parent)).toBe(true);
+		expect(cache.getTSConfigPath(parent)).toBe(real);
+		const root = path.dirname(real);
+		expect(cache.hasTSConfigPath(root)).toBe(true);
+		expect(cache.getTSConfigPath(root)).toBe(real);
+		cache.setTSConfigPath('fake', [dir, parent, root]);
+		for (const input of inputs) {
+			expect(await findNative(input, { cache }), `input: ${input}`).toBe('fake');
 		}
 	});
 

--- a/packages/tsconfck/tests/find-native.js
+++ b/packages/tsconfck/tests/find-native.js
@@ -65,7 +65,7 @@ describe('find-native', () => {
 		const relativeTS = relFixture(`${fixtureDir}/a/b/foo.ts`);
 		const absoluteTS = absFixture(`${fixtureDir}/a/b/foo.ts`);
 		const inputs = [relativeTS, `./${relativeTS}`, absoluteTS];
-		const real = absFixture(`${fixtureDir}/tsconfig.json`);
+		const real = native2posix(absFixture(`${fixtureDir}/tsconfig.json`));
 		const cache = new TSConfckCache();
 		for (const input of inputs) {
 			expect(await findNative(input, { cache }), `input: ${input}`).toBe(real);

--- a/packages/tsconfck/tests/find-native.js
+++ b/packages/tsconfck/tests/find-native.js
@@ -65,20 +65,21 @@ describe('find-native', () => {
 		const relativeTS = relFixture(`${fixtureDir}/a/b/foo.ts`);
 		const absoluteTS = absFixture(`${fixtureDir}/a/b/foo.ts`);
 		const inputs = [relativeTS, `./${relativeTS}`, absoluteTS];
-		const real = native2posix(absFixture(`${fixtureDir}/tsconfig.json`));
+		const real = absFixture(`${fixtureDir}/tsconfig.json`);
+		const expected = native2posix(real);
 		const cache = new TSConfckCache();
 		for (const input of inputs) {
-			expect(await findNative(input, { cache }), `input: ${input}`).toBe(real);
+			expect(await findNative(input, { cache }), `input: ${input}`).toBe(expected);
 		}
 		const dir = path.dirname(absoluteTS);
 		expect(cache.hasTSConfigPath(dir)).toBe(true);
-		expect(cache.getTSConfigPath(dir)).toBe(real);
+		expect(cache.getTSConfigPath(dir)).toBe(expected);
 		const parent = path.dirname(dir);
 		expect(cache.hasTSConfigPath(parent)).toBe(true);
-		expect(cache.getTSConfigPath(parent)).toBe(real);
+		expect(cache.getTSConfigPath(parent)).toBe(expected);
 		const root = path.dirname(real);
 		expect(cache.hasTSConfigPath(root)).toBe(true);
-		expect(cache.getTSConfigPath(root)).toBe(real);
+		expect(cache.getTSConfigPath(root)).toBe(expected);
 		cache.setTSConfigPath('fake', [dir, parent, root]);
 		for (const input of inputs) {
 			expect(await findNative(input, { cache }), `input: ${input}`).toBe('fake');

--- a/packages/tsconfck/tests/find.js
+++ b/packages/tsconfck/tests/find.js
@@ -66,7 +66,7 @@ describe('find', () => {
 		const fake = absFixture(`${fixtureDir}/a/tsconfig.json`);
 
 		const cache = new TSConfckCache();
-		cache.setTSConfigPath(fake, [path.dirname(fake)]);
+		cache.setTSConfigPath(path.dirname(fake), Promise.resolve(fake));
 
 		for (const input of inputs) {
 			expect(await find(input), `input: ${input}`).toBe(real);
@@ -74,7 +74,7 @@ describe('find', () => {
 		}
 		const added_key = path.dirname(absoluteTS);
 		expect(cache.hasTSConfigPath(added_key)).toBe(true);
-		expect(cache.getTSConfigPath(added_key)).toBe(fake);
+		expect(await cache.getTSConfigPath(added_key)).toBe(fake);
 	});
 
 	it('should reject when no tsconfig file was found', async () => {

--- a/packages/tsconfck/tests/find.js
+++ b/packages/tsconfck/tests/find.js
@@ -3,6 +3,7 @@ import path from 'path';
 import os from 'os';
 import { find } from '../src/find.js';
 import { absFixture, absRoot, relFixture } from './util/fixture-paths.js';
+import { TSConfckCache } from '../src/cache.js';
 
 describe('find', () => {
 	it('should be a function', () => {
@@ -56,7 +57,7 @@ describe('find', () => {
 		}
 	});
 
-	it('should use provided tsconfigPaths', async () => {
+	it('should use provided cache', async () => {
 		const fixtureDir = 'find-root';
 		const relativeTS = relFixture(`${fixtureDir}/a/b/foo.ts`);
 		const absoluteTS = absFixture(`${fixtureDir}/a/b/foo.ts`);
@@ -64,12 +65,16 @@ describe('find', () => {
 		const real = absFixture(`${fixtureDir}/tsconfig.json`);
 		const fake = absFixture(`${fixtureDir}/a/tsconfig.json`);
 
-		const tsconfigPaths = new Set([fake]);
+		const cache = new TSConfckCache();
+		cache.setTSConfigPath(fake, [path.dirname(fake)]);
 
 		for (const input of inputs) {
 			expect(await find(input), `input: ${input}`).toBe(real);
-			expect(await find(input, { tsconfigPaths }), `input: ${input}`).toBe(fake);
+			expect(await find(input, { cache }), `input: ${input}`).toBe(fake);
 		}
+		const added_key = path.dirname(absoluteTS);
+		expect(cache.hasTSConfigPath(added_key)).toBe(true);
+		expect(cache.getTSConfigPath(added_key)).toBe(fake);
 	});
 
 	it('should reject when no tsconfig file was found', async () => {

--- a/packages/tsconfck/tests/parse-native.js
+++ b/packages/tsconfck/tests/parse-native.js
@@ -10,6 +10,7 @@ import glob from 'tiny-glob';
 import { promises as fs } from 'fs';
 import { transform as esbuildTransform } from 'esbuild';
 import ts from 'typescript';
+import { TSConfckCache } from '../src/cache.js';
 
 describe('parse', () => {
 	it('should be a function', () => {
@@ -68,9 +69,9 @@ describe('parse', () => {
 			...(await globFixtures('parse/valid/with_extends/**/tsconfig.json')),
 			...(await globFixtures('parse/solution/**/*.ts'))
 		];
-		const cache = new Map();
+		const cache = new TSConfckCache();
 		for (const filename of samples) {
-			expect(cache.has(filename), `cache does not exist for ${filename}`).toBe(false);
+			expect(cache.hasParseResult(filename), `cache does not exist for ${filename}`).toBe(false);
 			const actual = await parseNative(filename, { cache });
 			await expectToMatchSnap(
 				actual.tsconfig,
@@ -78,8 +79,8 @@ describe('parse', () => {
 				filename,
 				filename.endsWith('tsconfig.json') ? 'parse-native' : '.tsconfig.parse-native.json'
 			);
-			expect(cache.has(filename), `cache exists for ${filename}`).toBe(true);
-			const cached = cache.get(filename);
+			expect(cache.hasParseResult(filename), `cache exists for ${filename}`).toBe(true);
+			const cached = cache.getParseResult(filename);
 			expect(cached.tsconfig, `input: ${filename} cached tsconfig is equal`).toEqual(
 				actual.tsconfig
 			);
@@ -87,10 +88,11 @@ describe('parse', () => {
 			expect(reparsedResult, `reparsedResult was returned from cache for ${filename}`).toBe(cached);
 
 			if (filename.endsWith('.ts')) {
-				expect(cache.has(actual.tsconfigFile), `cache exists for ${actual.tsconfigFile}`).toBe(
-					true
-				);
-				const cachedByResultFilename = cache.get(actual.tsconfigFile);
+				expect(
+					cache.hasParseResult(actual.tsconfigFile),
+					`cache exists for ${actual.tsconfigFile}`
+				).toBe(true);
+				const cachedByResultFilename = cache.getParseResult(actual.tsconfigFile);
 				expect(
 					cachedByResultFilename.tsconfig,
 					`cache of ${actual.tsconfigFile} matches for: ${filename}`
@@ -106,8 +108,10 @@ describe('parse', () => {
 			expect(newParse, `input: ${filename} new parse is different object from old cached`).not.toBe(
 				cached
 			);
-			expect(cache.has(filename), `cache exists again after clear for ${filename}`).toBe(true);
-			const newCached = cache.get(filename);
+			expect(cache.hasParseResult(filename), `cache exists again after clear for ${filename}`).toBe(
+				true
+			);
+			const newCached = cache.getParseResult(filename);
 			expect(newCached, `input: ${filename} new cache different object from old cached`).not.toBe(
 				cached
 			);

--- a/packages/tsconfck/tests/parse-native.js
+++ b/packages/tsconfck/tests/parse-native.js
@@ -103,7 +103,7 @@ describe('parse', () => {
 					`reparsedByResultFilename was returned from cache for ${actual.tsconfigFile}`
 				).toBe(cachedByResultFilename);
 			}
-			cache.clear();
+			await cache.clear();
 			const newParse = await parseNative(filename, { cache });
 			expect(newParse, `input: ${filename} new parse is different object from old cached`).not.toBe(
 				cached

--- a/packages/tsconfck/tests/parse.js
+++ b/packages/tsconfck/tests/parse.js
@@ -86,7 +86,7 @@ describe('parse', () => {
 				filename.endsWith('tsconfig.json') ? 'parse' : '.tsconfig.parse.json'
 			);
 			expect(cache.hasParseResult(filename), `cache exists for ${filename}`).toBe(true);
-			const cached = cache.getParseResult(filename);
+			const cached = await cache.getParseResult(filename);
 			expect(cached.tsconfig, `input: ${filename} cached tsconfig is equal`).toEqual(
 				actual.tsconfig
 			);
@@ -98,7 +98,7 @@ describe('parse', () => {
 					cache.hasParseResult(actual.tsconfigFile),
 					`cache exists for ${actual.tsconfigFile}`
 				).toBe(true);
-				const cachedByResultFilename = cache.getParseResult(actual.tsconfigFile);
+				const cachedByResultFilename = await cache.getParseResult(actual.tsconfigFile);
 				expect(
 					cachedByResultFilename.tsconfig,
 					`cache of ${actual.tsconfigFile} matches for: ${filename}`
@@ -117,7 +117,7 @@ describe('parse', () => {
 			expect(cache.hasParseResult(filename), `cache exists again after clear for ${filename}`).toBe(
 				true
 			);
-			const newCached = cache.getParseResult(filename);
+			const newCached = await cache.getParseResult(filename);
 			expect(newCached, `input: ${filename} new cache different object from old cached`).not.toBe(
 				cached
 			);

--- a/packages/tsconfck/tests/parse.js
+++ b/packages/tsconfck/tests/parse.js
@@ -109,7 +109,7 @@ describe('parse', () => {
 					`reparsedByResultFilename was returned from cache for ${actual.tsconfigFile}`
 				).toBe(cachedByResultFilename);
 			}
-			cache.clear();
+			await cache.clear();
 			const newParse = await parse(filename, { cache });
 			expect(newParse, `input: ${filename} new parse is different object from old cached`).not.toBe(
 				cached

--- a/packages/tsconfck/tests/parse.js
+++ b/packages/tsconfck/tests/parse.js
@@ -10,6 +10,7 @@ import glob from 'tiny-glob';
 import { promises as fs } from 'fs';
 import { transform as esbuildTransform } from 'esbuild';
 import ts from 'typescript';
+import { TSConfckCache } from '../src/cache.js';
 
 describe('parse', () => {
 	it('should be a function', () => {
@@ -74,9 +75,9 @@ describe('parse', () => {
 			...(await globFixtures('parse/valid/with_extends/**/tsconfig.json')),
 			...(await globFixtures('parse/solution/**/*.ts'))
 		];
-		const cache = new Map();
+		const cache = new TSConfckCache();
 		for (const filename of samples) {
-			expect(cache.has(filename), `cache does not exist for ${filename}`).toBe(false);
+			expect(cache.hasParseResult(filename), `cache does not exist for ${filename}`).toBe(false);
 			const actual = await parse(filename, { cache });
 			await expectToMatchSnap(
 				actual.tsconfig,
@@ -84,8 +85,8 @@ describe('parse', () => {
 				filename,
 				filename.endsWith('tsconfig.json') ? 'parse' : '.tsconfig.parse.json'
 			);
-			expect(cache.has(filename), `cache exists for ${filename}`).toBe(true);
-			const cached = cache.get(filename);
+			expect(cache.hasParseResult(filename), `cache exists for ${filename}`).toBe(true);
+			const cached = cache.getParseResult(filename);
 			expect(cached.tsconfig, `input: ${filename} cached tsconfig is equal`).toEqual(
 				actual.tsconfig
 			);
@@ -93,10 +94,11 @@ describe('parse', () => {
 			expect(reparsedResult, `reparsedResult was returned from cache for ${filename}`).toBe(cached);
 
 			if (filename.endsWith('.ts')) {
-				expect(cache.has(actual.tsconfigFile), `cache exists for ${actual.tsconfigFile}`).toBe(
-					true
-				);
-				const cachedByResultFilename = cache.get(actual.tsconfigFile);
+				expect(
+					cache.hasParseResult(actual.tsconfigFile),
+					`cache exists for ${actual.tsconfigFile}`
+				).toBe(true);
+				const cachedByResultFilename = cache.getParseResult(actual.tsconfigFile);
 				expect(
 					cachedByResultFilename.tsconfig,
 					`cache of ${actual.tsconfigFile} matches for: ${filename}`
@@ -112,8 +114,10 @@ describe('parse', () => {
 			expect(newParse, `input: ${filename} new parse is different object from old cached`).not.toBe(
 				cached
 			);
-			expect(cache.has(filename), `cache exists again after clear for ${filename}`).toBe(true);
-			const newCached = cache.get(filename);
+			expect(cache.hasParseResult(filename), `cache exists again after clear for ${filename}`).toBe(
+				true
+			);
+			const newCached = cache.getParseResult(filename);
 			expect(newCached, `input: ${filename} new cache different object from old cached`).not.toBe(
 				cached
 			);

--- a/packages/tsconfck/tests/snapshots/parse/valid/with_extends/node/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/with_extends/node/tsconfig.json.parse.json
@@ -8,7 +8,7 @@
 		"lib": [
 			"es2023"
 		],
-		"module": "Node16",
+		"module": "node16",
 		"target": "es2022",
 		"strict": true,
 		"esModuleInterop": true,

--- a/packages/tsconfck/tests/snapshots/parse/valid/with_extends/node_fallback/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/with_extends/node_fallback/tsconfig.json.parse.json
@@ -8,7 +8,7 @@
 		"lib": [
 			"es2023"
 		],
-		"module": "Node16",
+		"module": "node16",
 		"target": "es2022",
 		"strict": true,
 		"esModuleInterop": true,

--- a/packages/tsconfck/tests/util/expect.js
+++ b/packages/tsconfck/tests/util/expect.js
@@ -35,7 +35,7 @@ export async function expectToMatchSnap(actual, message, inputFile, suffix) {
 	}
 	const normalizedValue = normalizeSnapshot(toJSON ? JSON.stringify(actual, null, '\t') : actual);
 
-	await expect(normalizedValue, message).toMatchFileSnapshot(snapName(inputFile, suffix));
+	await expect(normalizedValue, message).toMatchFileSnapshot(snapName(inputFile, suffix), message);
 }
 
 /**

--- a/packages/tsconfck/types/index.d.ts
+++ b/packages/tsconfck/types/index.d.ts
@@ -45,7 +45,7 @@ declare module 'tsconfck' {
 		/**
 		 * get cached closest tsconfig for files in dir
 		 * */
-		getTSConfigPath(dir: string): Promise<string>;
+		getTSConfigPath(dir: string): Awaitable<string | null>;
 		/**
 		 * has parsed tsconfig for file
 		 * */
@@ -53,7 +53,7 @@ declare module 'tsconfck' {
 		/**
 		 * get parsed tsconfig for file
 		 * */
-		getParseResult(file: string): Promise<TSConfckParseResult | TSConfckParseNativeResult>;
+		getParseResult(file: string): Awaitable<TSConfckParseResult | TSConfckParseNativeResult>;
 		
 		private setParseResult;
 		
@@ -90,7 +90,6 @@ declare module 'tsconfck' {
 		 * absolute path of tsconfig file where the error happened
 		 * */
 		tsconfigFile: string;
-		name: any;
 	}
 	/**
 	 * parse the closest tsconfig.json file with typescript native functions
@@ -109,7 +108,6 @@ declare module 'tsconfck' {
 		 * @param result  - parsed result, if any
 		 */
 		constructor(diagnostic: any, tsconfigFile: string, result: any | null);
-		name: any;
 		/**
 		 * code of typescript diagnostic, prefixed with "TS "
 		 * */
@@ -227,6 +225,8 @@ declare module 'tsconfck' {
 		 */
 		result: any;
 	}
+
+	type Awaitable<T> = Promise<T> | T;
 }
 
 //# sourceMappingURL=index.d.ts.map

--- a/packages/tsconfck/types/index.d.ts
+++ b/packages/tsconfck/types/index.d.ts
@@ -35,8 +35,9 @@ declare module 'tsconfck' {
 	export class TSConfckCache {
 		/**
 		 * clear cache, use this if you have a long running process and tsconfig files have been added,changed or deleted
+		 * await it to ensure all find and parse calls are settled before continuing
 		 */
-		clear(): void;
+		clear(): Promise<void>;
 		/**
 		 * has cached closest tsconfig for files in dir
 		 * */

--- a/packages/tsconfck/types/index.d.ts
+++ b/packages/tsconfck/types/index.d.ts
@@ -37,18 +37,26 @@ declare module 'tsconfck' {
 		 * clear cache, use this if you have a long running process and tsconfig files have been added,changed or deleted
 		 */
 		clear(): void;
-		
-		private setTSConfigPath;
-		
-		private getTSConfigPath;
-		
-		private hasTSConfigPath;
-		
-		private getParseResult;
+		/**
+		 * has cached closest tsconfig for files in dir
+		 * */
+		hasTSConfigPath(dir: string): boolean;
+		/**
+		 * get cached closest tsconfig for files in dir
+		 * */
+		getTSConfigPath(dir: string): string;
+		/**
+		 * has parsed tsconfig for file
+		 * */
+		hasParseResult(file: string): boolean;
+		/**
+		 * get parsed tsconfig for file
+		 * */
+		getParseResult(file: string): TSConfckParseResult | TSConfckParseNativeResult;
 		
 		private setParseResult;
 		
-		private hasParseResult;
+		private setTSConfigPath;
 		#private;
 	}
 	/**

--- a/packages/tsconfck/types/index.d.ts
+++ b/packages/tsconfck/types/index.d.ts
@@ -32,6 +32,25 @@ declare module 'tsconfck' {
 	 * @returns absolute path to closest tsconfig.json
 	 */
 	export function findNative(filename: string, options?: TSConfckFindOptions | undefined): Promise<string>;
+	export class TSConfckCache {
+		/**
+		 * clear cache, use this if you have a long running process and tsconfig files have been added,changed or deleted
+		 */
+		clear(): void;
+		
+		private setTSConfigPath;
+		
+		private getTSConfigPath;
+		
+		private hasTSConfigPath;
+		
+		private getParseResult;
+		
+		private setParseResult;
+		
+		private hasParseResult;
+		#private;
+	}
 	/**
 	 * parse the closest tsconfig.json file
 	 *
@@ -196,25 +215,6 @@ declare module 'tsconfck' {
 		 * full output of ts.parseJsonConfigFileContent
 		 */
 		result: any;
-	}
-	class TSConfckCache {
-		/**
-		 * clear cache, use this if you have a long running process and tsconfig files have been added,changed or deleted
-		 */
-		clear(): void;
-		
-		setTSConfigPath(tsconfigPath: string, directories: string[]): void;
-		
-		getTSConfigPath(dir: string): string;
-		
-		hasTSConfigPath(dir: string): boolean;
-		
-		getParseResult(file: string): TSConfckParseResult | TSConfckParseNativeResult;
-		
-		setParseResult(file: any, result: TSConfckParseResult | TSConfckParseNativeResult): void;
-		
-		hasParseResult(file: string): boolean;
-		#private;
 	}
 }
 

--- a/packages/tsconfck/types/index.d.ts
+++ b/packages/tsconfck/types/index.d.ts
@@ -52,9 +52,11 @@ declare module 'tsconfck' {
 		/**
 		 * get parsed tsconfig for file
 		 * */
-		getParseResult(file: string): TSConfckParseResult | TSConfckParseNativeResult;
+		getParseResult(file: string): Promise<TSConfckParseResult | TSConfckParseNativeResult>;
 		
 		private setParseResult;
+		
+		private deleteParseResult;
 		
 		private setTSConfigPath;
 		#private;

--- a/packages/tsconfck/types/index.d.ts
+++ b/packages/tsconfck/types/index.d.ts
@@ -44,7 +44,7 @@ declare module 'tsconfck' {
 		/**
 		 * get cached closest tsconfig for files in dir
 		 * */
-		getTSConfigPath(dir: string): string;
+		getTSConfigPath(dir: string): Promise<string>;
 		/**
 		 * has parsed tsconfig for file
 		 * */

--- a/packages/tsconfck/types/index.d.ts
+++ b/packages/tsconfck/types/index.d.ts
@@ -28,9 +28,10 @@ declare module 'tsconfck' {
 	 * You must have `typescript` installed to use this
 	 *
 	 * @param filename - path to file to find tsconfig for (absolute or relative to cwd)
+	 * @param options - options
 	 * @returns absolute path to closest tsconfig.json
 	 */
-	export function findNative(filename: string): Promise<string>;
+	export function findNative(filename: string, options?: TSConfckFindOptions | undefined): Promise<string>;
 	/**
 	 * parse the closest tsconfig.json file
 	 *
@@ -98,12 +99,11 @@ declare module 'tsconfck' {
 	}
 	interface TSConfckFindOptions {
 		/**
-		 * Set of known tsconfig file locations to use instead of scanning the file system
+		 * A cache to improve performance for multiple calls in the same project
 		 *
-		 * This is better for performance in projects like vite where find is called frequently but tsconfig locations rarely change
-		 * You can use `findAll` to build this
+		 * Warning: You must clear this cache in case tsconfig files are added/removed during it's lifetime
 		 */
-		tsconfigPaths?: Set<string>;
+		cache?: TSConfckCache;
 
 		/**
 		 * project root dir, does not continue scanning outside of this directory.
@@ -123,15 +123,6 @@ declare module 'tsconfck' {
 	}
 
 	interface TSConfckParseOptions extends TSConfckFindOptions {
-		/**
-		 * optional cache map to speed up repeated parsing with multiple files
-		 * it is your own responsibility to clear the cache if tsconfig files change during its lifetime
-		 * cache keys are input `filename` and absolute paths to tsconfig.json files
-		 *
-		 * You must not modify cached values.
-		 */
-		cache?: Map<string, TSConfckParseResult>;
-
 		/**
 		 * treat missing tsconfig as empty result instead of an error
 		 * parse resolves with { filename: 'no_tsconfig_file_found',tsconfig:{}} instead of reject with error
@@ -168,22 +159,7 @@ declare module 'tsconfck' {
 		extended?: TSConfckParseResult[];
 	}
 
-	interface TSConfckParseNativeOptions {
-		/**
-		 * optional cache map to speed up repeated parsing with multiple files
-		 * it is your own responsibility to clear the cache if tsconfig files change during its lifetime
-		 * cache keys are input `filename` and absolute paths to tsconfig.json files
-		 *
-		 * You must not modify cached values.
-		 */
-		cache?: Map<string, TSConfckParseNativeResult>;
-
-		/**
-		 * treat missing tsconfig as empty result instead of an error
-		 * parseNative resolves with { filename: 'no_tsconfig_file_found',tsconfig:{}, result: null} instead of reject with error
-		 */
-		resolveWithEmptyIfConfigNotFound?: boolean;
-
+	interface TSConfckParseNativeOptions extends TSConfckParseOptions {
 		/**
 		 * Set this option to true to force typescript to ignore all source files.
 		 *
@@ -220,6 +196,25 @@ declare module 'tsconfck' {
 		 * full output of ts.parseJsonConfigFileContent
 		 */
 		result: any;
+	}
+	class TSConfckCache {
+		/**
+		 * clear cache, use this if you have a long running process and tsconfig files have been added,changed or deleted
+		 */
+		clear(): void;
+		
+		setTSConfigPath(tsconfigPath: string, directories: string[]): void;
+		
+		getTSConfigPath(dir: string): string;
+		
+		hasTSConfigPath(dir: string): boolean;
+		
+		getParseResult(file: string): TSConfckParseResult | TSConfckParseNativeResult;
+		
+		setParseResult(file: any, result: TSConfckParseResult | TSConfckParseNativeResult): void;
+		
+		hasParseResult(file: string): boolean;
+		#private;
 	}
 }
 

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -38,5 +38,5 @@
 		null,
 		null
 	],
-	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCZnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCqBJC,KAAKA;cA0TdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC3TTC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;WCnPpBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;WAQpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
+	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCZnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCqBJC,KAAKA;cA0TdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC3TTC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;WCnPpBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;WAQpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
 }

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -15,7 +15,8 @@
 		"TSConfckParseOptions",
 		"TSConfckParseResult",
 		"TSConfckParseNativeOptions",
-		"TSConfckParseNativeResult"
+		"TSConfckParseNativeResult",
+		"TSConfckCache"
 	],
 	"sources": [
 		"../src/find.js",
@@ -24,7 +25,8 @@
 		"../src/find-native.js",
 		"../src/parse.js",
 		"../src/parse-native.js",
-		"../src/public.d.ts"
+		"../src/public.d.ts",
+		"../src/cache.js"
 	],
 	"sourcesContent": [
 		null,
@@ -33,7 +35,8 @@
 		null,
 		null,
 		null,
+		null,
 		null
 	],
-	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;iBCFAC,UAAUA;;;;;;;iBCUVC,KAAKA;cA8SdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC/STC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;WCrPpBC,mBAAmBA;;;;;;;;;;;;;;;;;WAiBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;;;;;;;;;;WAiBpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;;;;;;;;;;;;;;;;WA2B1BC,yBAAyBA"
+	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;;;;;;;iBCSVC,KAAKA;cA8SdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC/STC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;WCnPpBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;WAQpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA;;;;;;;;;;;;;;;;;;;;;;;;;;OC5E7BC,aAAaA"
 }

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -38,5 +38,5 @@
 		null,
 		null
 	],
-	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCZnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;iBCqBJC,KAAKA;cA8SdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC/STC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;WCnPpBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;WAQpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
+	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCZnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCqBJC,KAAKA;cA8SdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC/STC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;WCnPpBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;WAQpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
 }

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -38,5 +38,5 @@
 		null,
 		null
 	],
-	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCZnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCqBJC,KAAKA;cA8SdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC/STC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;WCnPpBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;WAQpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
+	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCZnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCqBJC,KAAKA;cA0TdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC3TTC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;WCnPpBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;WAQpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
 }

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -6,6 +6,7 @@
 		"findAll",
 		"toJson",
 		"findNative",
+		"TSConfckCache",
 		"parse",
 		"TSConfckParseError",
 		"parseNative",
@@ -15,18 +16,17 @@
 		"TSConfckParseOptions",
 		"TSConfckParseResult",
 		"TSConfckParseNativeOptions",
-		"TSConfckParseNativeResult",
-		"TSConfckCache"
+		"TSConfckParseNativeResult"
 	],
 	"sources": [
 		"../src/find.js",
 		"../src/find-all.js",
 		"../src/to-json.js",
 		"../src/find-native.js",
+		"../src/cache.js",
 		"../src/parse.js",
 		"../src/parse-native.js",
-		"../src/public.d.ts",
-		"../src/cache.js"
+		"../src/public.d.ts"
 	],
 	"sourcesContent": [
 		null,
@@ -38,5 +38,5 @@
 		null,
 		null
 	],
-	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;;;;;;;iBCSVC,KAAKA;cA8SdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC/STC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;WCnPpBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;WAQpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA;;;;;;;;;;;;;;;;;;;;;;;;;;OC5E7BC,aAAaA"
+	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCZnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;iBCqBJC,KAAKA;cA8SdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC/STC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;WCnPpBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;WAQpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
 }

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -16,7 +16,8 @@
 		"TSConfckParseOptions",
 		"TSConfckParseResult",
 		"TSConfckParseNativeOptions",
-		"TSConfckParseNativeResult"
+		"TSConfckParseNativeResult",
+		"Awaitable"
 	],
 	"sources": [
 		"../src/find.js",
@@ -38,5 +39,5 @@
 		null,
 		null
 	],
-	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCZnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCqBJC,KAAKA;cA0TdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC3TTC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;WCnPpBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;WAQpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
+	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCZnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCqBJC,KAAKA;cAyTdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC1TTC,WAAWA;cAiOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;WCnPpBC,mBAAmBA;;;;;;;;;;;;;;;;WAgBnBC,sBAAsBA;;;;;;;;;WAStBC,oBAAoBA;;;;;;;;WAQpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA;;;;;;;;;;;;;;;;;;;;;;;;;;;MA2B9BC,SAASA"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,56 +15,56 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       dts-buddy:
-        specifier: ^0.1.12
-        version: 0.1.12
+        specifier: ^0.2.4
+        version: 0.2.4
       eslint:
-        specifier: ^8.46.0
-        version: 8.46.0
+        specifier: ^8.48.0
+        version: 8.48.0
       eslint-config-prettier:
-        specifier: ^8.10.0
-        version: 8.10.0(eslint@8.46.0)
+        specifier: ^9.0.0
+        version: 9.0.0(eslint@8.48.0)
       eslint-plugin-markdown:
         specifier: ^3.0.1
-        version: 3.0.1(eslint@8.46.0)
+        version: 3.0.1(eslint@8.48.0)
       eslint-plugin-n:
-        specifier: ^16.0.1
-        version: 16.0.1(eslint@8.46.0)
+        specifier: ^16.0.2
+        version: 16.0.2(eslint@8.48.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@8.10.0)(eslint@8.46.0)(prettier@3.0.1)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.48.0)(prettier@3.0.3)
       lint-staged:
-        specifier: ^14.0.0
-        version: 14.0.0
+        specifier: ^14.0.1
+        version: 14.0.1
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
       prettier:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.3
+        version: 3.0.3
       publint:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.2
+        version: 0.2.2
       vitest:
-        specifier: ^0.34.1
-        version: 0.34.1
+        specifier: ^0.34.3
+        version: 0.34.3
 
   packages/tsconfck:
     devDependencies:
       '@tsconfig/node18':
-        specifier: ^18.2.0
-        version: 18.2.0
+        specifier: ^18.2.1
+        version: 18.2.1
       esbuild:
-        specifier: ^0.19.1
-        version: 0.19.1
+        specifier: ^0.19.2
+        version: 0.19.2
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9
       typescript:
-        specifier: ^5.1.6
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vitest:
-        specifier: ^0.34.1
-        version: 0.34.1
+        specifier: ^0.34.3
+        version: 0.34.3
 
 packages:
 
@@ -73,11 +73,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /@babel/code-frame@7.22.5:
-    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
+  /@babel/code-frame@7.22.13:
+    resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.22.5
+      '@babel/highlight': 7.22.13
+      chalk: 2.4.2
     dev: true
 
   /@babel/helper-validator-identifier@7.22.5:
@@ -85,8 +86,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/highlight@7.22.5:
-    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
+  /@babel/highlight@7.22.13:
+    resolution: {integrity: sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-validator-identifier': 7.22.5
@@ -94,17 +95,17 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/runtime@7.22.6:
-    resolution: {integrity: sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==}
+  /@babel/runtime@7.22.11:
+    resolution: {integrity: sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      regenerator-runtime: 0.13.11
+      regenerator-runtime: 0.14.0
     dev: true
 
   /@changesets/apply-release-plan@6.1.4:
     resolution: {integrity: sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.22.11
       '@changesets/config': 2.3.1
       '@changesets/get-version-range-type': 0.3.2
       '@changesets/git': 2.0.0
@@ -122,7 +123,7 @@ packages:
   /@changesets/assemble-release-plan@5.2.4:
     resolution: {integrity: sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.22.11
       '@changesets/errors': 0.1.4
       '@changesets/get-dependents-graph': 1.3.6
       '@changesets/types': 5.2.1
@@ -140,7 +141,7 @@ packages:
     resolution: {integrity: sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.22.11
       '@changesets/apply-release-plan': 6.1.4
       '@changesets/assemble-release-plan': 5.2.4
       '@changesets/changelog-git': 0.1.14
@@ -156,7 +157,7 @@ packages:
       '@changesets/write': 0.2.3
       '@manypkg/get-packages': 1.1.3
       '@types/is-ci': 3.0.0
-      '@types/semver': 7.5.0
+      '@types/semver': 7.5.1
       ansi-colors: 4.1.3
       chalk: 2.4.2
       enquirer: 2.4.1
@@ -207,7 +208,7 @@ packages:
     resolution: {integrity: sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==}
     dependencies:
       dataloader: 1.4.0
-      node-fetch: 2.6.12
+      node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -215,7 +216,7 @@ packages:
   /@changesets/get-release-plan@3.0.17:
     resolution: {integrity: sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.22.11
       '@changesets/assemble-release-plan': 5.2.4
       '@changesets/config': 2.3.1
       '@changesets/pre': 1.0.14
@@ -231,7 +232,7 @@ packages:
   /@changesets/git@2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.22.11
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -256,7 +257,7 @@ packages:
   /@changesets/pre@1.0.14:
     resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.22.11
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -266,7 +267,7 @@ packages:
   /@changesets/read@0.5.9:
     resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.22.11
       '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
       '@changesets/parse': 0.3.16
@@ -287,15 +288,15 @@ packages:
   /@changesets/write@0.2.3:
     resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.22.11
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.8
     dev: true
 
-  /@esbuild/android-arm64@0.18.18:
-    resolution: {integrity: sha512-dkAPYzRHq3dNXIzOyAknYOzsx8o3KWaNiuu56B2rP9IFPmFWMS58WQcTlUQi6iloku8ZyHHMluCe5sTWhKq/Yw==}
+  /@esbuild/android-arm64@0.18.20:
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -303,8 +304,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm64@0.19.1:
-    resolution: {integrity: sha512-CqhrKvDSt76I0so/5afqgKrMv41FjbfUKFrcZddMnrZKqJU70I1MWLVJrImJuYMaY4Yb9rn4UKfF7oZ0BOleVw==}
+  /@esbuild/android-arm64@0.19.2:
+    resolution: {integrity: sha512-lsB65vAbe90I/Qe10OjkmrdxSX4UJDjosDgb8sZUKcg3oefEuW2OT2Vozz8ef7wrJbMcmhvCC+hciF8jY/uAkw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -312,8 +313,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.18.18:
-    resolution: {integrity: sha512-oBymf7ZwplAawSxmiSlBCf+FMcY0f4bs5QP2jn43JKUf0M9DnrUTjqa5RvFPl1elw+sMfcpfBRPK+rb+E1q7zg==}
+  /@esbuild/android-arm@0.18.20:
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -321,8 +322,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.19.1:
-    resolution: {integrity: sha512-yjTucwcOua52z14RL30JMwmCdylsQ5WrErGkAb6VL0MWPbnwJyLejydaRcUqkPO6g0MowlzavdxrR7AcfCW+yA==}
+  /@esbuild/android-arm@0.19.2:
+    resolution: {integrity: sha512-tM8yLeYVe7pRyAu9VMi/Q7aunpLwD139EY1S99xbQkT4/q2qa6eA4ige/WJQYdJ8GBL1K33pPFhPfPdJ/WzT8Q==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -330,8 +331,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.18.18:
-    resolution: {integrity: sha512-r7/pVcrUQMYkjvtE/1/n6BxhWM+/9tvLxDG1ev1ce4z3YsqoxMK9bbOM6bFcj0BowMeGQvOZWcBV182lFFKmrw==}
+  /@esbuild/android-x64@0.18.20:
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -339,8 +340,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.19.1:
-    resolution: {integrity: sha512-VA29h01MrPkymIL1bFtvL2L4WPogiMGW2N/M+vXZHHOv6LgA9vjzVskTt0v5LjeCjx1PFDcR0ASKy8Y7Gm+iIA==}
+  /@esbuild/android-x64@0.19.2:
+    resolution: {integrity: sha512-qK/TpmHt2M/Hg82WXHRc/W/2SGo/l1thtDHZWqFq7oi24AjZ4O/CpPSu6ZuYKFkEgmZlFoa7CooAyYmuvnaG8w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -348,8 +349,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.18.18:
-    resolution: {integrity: sha512-MSe2iV9MAH3wfP0g+vzN9bp36rtPPuCSk+bT5E2vv/d8krvW5uB/Pi/Q5+txUZuxsG3GcO8dhygjnFq0wJU9hQ==}
+  /@esbuild/darwin-arm64@0.18.20:
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -357,8 +358,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.19.1:
-    resolution: {integrity: sha512-Be4Cf6WDH7QkLHEpfzQOlBOFdqmqYTSqw2yG3SVmzB3++wy3K7wiNGedezL+q6Jb4weqT9tchO5kkLDC08Jnzg==}
+  /@esbuild/darwin-arm64@0.19.2:
+    resolution: {integrity: sha512-Ora8JokrvrzEPEpZO18ZYXkH4asCdc1DLdcVy8TGf5eWtPO1Ie4WroEJzwI52ZGtpODy3+m0a2yEX9l+KUn0tA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -366,8 +367,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.18.18:
-    resolution: {integrity: sha512-ARFYISOWkaifjcr48YtO70gcDNeOf1H2RnmOj6ip3xHIj66f3dAbhcd5Nph5np6oHI7DhHIcr9MWO18RvUL1bw==}
+  /@esbuild/darwin-x64@0.18.20:
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -375,8 +376,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.19.1:
-    resolution: {integrity: sha512-SewtenJi6zCEfZRSUchb+LgJ/IQw8QvnKECPu/qHII1fLQKnVPUVR+VH2IuS03DD9WWnAi3yfOvBNwtrp3WXtg==}
+  /@esbuild/darwin-x64@0.19.2:
+    resolution: {integrity: sha512-tP+B5UuIbbFMj2hQaUr6EALlHOIOmlLM2FK7jeFBobPy2ERdohI4Ka6ZFjZ1ZYsrHE/hZimGuU90jusRE0pwDw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -384,8 +385,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.18.18:
-    resolution: {integrity: sha512-BHnXmexzEWRU2ZySJosU0Ts0NRnJnNrMB6t4EiIaOSel73I8iLsNiTPLH0rJulAh19cYZutsB5XHK6N8fi5eMg==}
+  /@esbuild/freebsd-arm64@0.18.20:
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -393,8 +394,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.19.1:
-    resolution: {integrity: sha512-TadKO0AaTDAPV2RyGZQ0AaiDTVYg7RsgNaA6OJjXXmoLbTs++NwHtzAmVFBq8Q/P9A11wgkv36HeyAYhWHbW1w==}
+  /@esbuild/freebsd-arm64@0.19.2:
+    resolution: {integrity: sha512-YbPY2kc0acfzL1VPVK6EnAlig4f+l8xmq36OZkU0jzBVHcOTyQDhnKQaLzZudNJQyymd9OqQezeaBgkTGdTGeQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -402,8 +403,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.18.18:
-    resolution: {integrity: sha512-n823w35wm0ZOobbuE//0sJjuz1Qj619+AwjgOcAJMN2pomZhH9BONCtn+KlfrmM/NWZ+27yB/eGVFzUIWLeh3w==}
+  /@esbuild/freebsd-x64@0.18.20:
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -411,8 +412,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.19.1:
-    resolution: {integrity: sha512-DrFMGLF0/aAcZgwhtZr1cby7aHlalpFjLCe5CiI8mm0Kqhhc8gyNZKreaZzvir8CQe0H17p9xx6M9ben5R3r0g==}
+  /@esbuild/freebsd-x64@0.19.2:
+    resolution: {integrity: sha512-nSO5uZT2clM6hosjWHAsS15hLrwCvIWx+b2e3lZ3MwbYSaXwvfO528OF+dLjas1g3bZonciivI8qKR/Hm7IWGw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -420,8 +421,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.18.18:
-    resolution: {integrity: sha512-zANxnwF0sCinDcAqoMohGoWBK9QaFJ65Vgh0ZE+RXtURaMwx+RfmfLElqtnn7X8OYNckMoIXSg7u+tZ3tqTlrA==}
+  /@esbuild/linux-arm64@0.18.20:
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -429,8 +430,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.19.1:
-    resolution: {integrity: sha512-6ku/R2EzsdjyBaqQn+xGOPbv+BBYBXQYzlA04/46YQLmXkdApi0GYyUwiCXYBxm578iyywzGmM0rep1/q8tuFQ==}
+  /@esbuild/linux-arm64@0.19.2:
+    resolution: {integrity: sha512-ig2P7GeG//zWlU0AggA3pV1h5gdix0MA3wgB+NsnBXViwiGgY77fuN9Wr5uoCrs2YzaYfogXgsWZbm+HGr09xg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -438,8 +439,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.18.18:
-    resolution: {integrity: sha512-Kck3jxPLQU4VeAGwe8Q4NU+IWIx+suULYOFUI9T0C2J1+UQlOHJ08ITN+MaJJ+2youzJOmKmcphH/t3SJxQ1Tw==}
+  /@esbuild/linux-arm@0.18.20:
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -447,8 +448,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.19.1:
-    resolution: {integrity: sha512-lCWDVPpQO/Dt5MEqctKujgtUVmwQx7J2Q83EqX/9BejN7BIX4fGJ0QKMiIyy21PFh+/64ArN+Ovh1tzYkTt2wg==}
+  /@esbuild/linux-arm@0.19.2:
+    resolution: {integrity: sha512-Odalh8hICg7SOD7XCj0YLpYCEc+6mkoq63UnExDCiRA2wXEmGlK5JVrW50vZR9Qz4qkvqnHcpH+OFEggO3PgTg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -456,8 +457,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.18.18:
-    resolution: {integrity: sha512-+VHz2sIRlY5u8IlaLJpdf5TL2kM76yx186pW7bpTB+vLWpzcFQVP04L842ZB2Ty13A1VXUvy3DbU1jV65P2skg==}
+  /@esbuild/linux-ia32@0.18.20:
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -465,8 +466,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.19.1:
-    resolution: {integrity: sha512-8AKFBk9v/zBDsADvK/0BWZUxkjEc0QDwO8rvbHJKqAZx6DF/VSeBxTRmqWeecrJmx+n3kemEwML9z0eD9IHweQ==}
+  /@esbuild/linux-ia32@0.19.2:
+    resolution: {integrity: sha512-mLfp0ziRPOLSTek0Gd9T5B8AtzKAkoZE70fneiiyPlSnUKKI4lp+mGEnQXcQEHLJAcIYDPSyBvsUbKUG2ri/XQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -474,8 +475,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.18.18:
-    resolution: {integrity: sha512-fXPEPdeGBvguo/1+Na8OIWz3667BN1cwbGtTEZWTd0qdyTsk5gGf9jVX8MblElbDb/Cpw6y5JiaQuL96YmvBwQ==}
+  /@esbuild/linux-loong64@0.18.20:
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -483,8 +484,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.19.1:
-    resolution: {integrity: sha512-6mOS5CxTGD8qOymp2y4KoM4ir+/REgjdJQFYpwP+WqjrWBo+PUevDGeHHjzCdw/R19PkFqS1bRzv8cTCmB/5kA==}
+  /@esbuild/linux-loong64@0.19.2:
+    resolution: {integrity: sha512-hn28+JNDTxxCpnYjdDYVMNTR3SKavyLlCHHkufHV91fkewpIyQchS1d8wSbmXhs1fiYDpNww8KTFlJ1dHsxeSw==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -492,8 +493,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.18.18:
-    resolution: {integrity: sha512-dLvRB87pIBIRnEIC32LIcgwK1JzlIuADIRjLKdUIpxauKwMuS/xMpN+cFl+0nN4RHNYOZ57DmXFFmQAcdlFOmw==}
+  /@esbuild/linux-mips64el@0.18.20:
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -501,8 +502,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.19.1:
-    resolution: {integrity: sha512-Bzmv6rRMzR4ErG2k/jwfj5jKNzVMVEI1tThuirFdAoE+duUv+jlDnlwxsN3s1eqMzADTOV2sSIcUUOfgv++Dgg==}
+  /@esbuild/linux-mips64el@0.19.2:
+    resolution: {integrity: sha512-KbXaC0Sejt7vD2fEgPoIKb6nxkfYW9OmFUK9XQE4//PvGIxNIfPk1NmlHmMg6f25x57rpmEFrn1OotASYIAaTg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -510,8 +511,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.18.18:
-    resolution: {integrity: sha512-fRChqIJZ7hLkXSKfBLYgsX9Ssb5OGCjk3dzCETF5QSS1qjTgayLv0ALUdJDB9QOh/nbWwp+qfLZU6md4XcjL7w==}
+  /@esbuild/linux-ppc64@0.18.20:
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -519,8 +520,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.19.1:
-    resolution: {integrity: sha512-mPOxA7bd3nmx8TkuO/9M/tE0fnvmuX0wlpwnTL6DPLgkb/Z/KkupexSIw4cLfznn/fPzD89y17VWBjlVNyrpCQ==}
+  /@esbuild/linux-ppc64@0.19.2:
+    resolution: {integrity: sha512-dJ0kE8KTqbiHtA3Fc/zn7lCd7pqVr4JcT0JqOnbj4LLzYnp+7h8Qi4yjfq42ZlHfhOCM42rBh0EwHYLL6LEzcw==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -528,8 +529,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.18.18:
-    resolution: {integrity: sha512-ALK/BT3u7Hoa/vHjow6W6+MKF0ohYcVcVA1EpskI4bkBPVuDLrUDqt2YFifg5UcZc8qup0CwQqWmFUd6VMNgaA==}
+  /@esbuild/linux-riscv64@0.18.20:
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -537,8 +538,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.19.1:
-    resolution: {integrity: sha512-znYb2Mhe9xKIDeIYuTD6vCcUltvYzRT5Yq6sVcdhPrGu8DRdsNZS04B2tSeM+j7T03jL4yY+7/G/jxSJJ9LX2A==}
+  /@esbuild/linux-riscv64@0.19.2:
+    resolution: {integrity: sha512-7Z/jKNFufZ/bbu4INqqCN6DDlrmOTmdw6D0gH+6Y7auok2r02Ur661qPuXidPOJ+FSgbEeQnnAGgsVynfLuOEw==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -546,8 +547,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.18.18:
-    resolution: {integrity: sha512-crT7jtOXd9iirY65B+mJQ6W0HWdNy8dtkZqKGWNcBnunpLcTCfne5y5bKic9bhyYzKpQEsO+C/VBPD8iF0RhRw==}
+  /@esbuild/linux-s390x@0.18.20:
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -555,8 +556,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.19.1:
-    resolution: {integrity: sha512-BBIE32cyqAYhMOQ42/jnecoF5P/S5lMob2vXSUiFpD3xCFbXOFkjP1OjfFKnalSO9+B5emvPTQFfNQXuLeVGEw==}
+  /@esbuild/linux-s390x@0.19.2:
+    resolution: {integrity: sha512-U+RinR6aXXABFCcAY4gSlv4CL1oOVvSSCdseQmGO66H+XyuQGZIUdhG56SZaDJQcLmrSfRmx5XZOWyCJPRqS7g==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -564,8 +565,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.18.18:
-    resolution: {integrity: sha512-/NSgghjBOW9ELqjXDYxOCCIsvQUZpvua1/6NdnA9Vnrp9UzEydyDdFXljUjMMS9p5KxMzbMO9frjHYGVHBfCHg==}
+  /@esbuild/linux-x64@0.18.20:
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -573,8 +574,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.19.1:
-    resolution: {integrity: sha512-PoCvKdHTIbnHmVJ5OEdewGMSw40HDFRTrC/imwh8vrp695RbSUpOqBqNBT45neK0FQleGFbSE/A9X6HlXPDhqA==}
+  /@esbuild/linux-x64@0.19.2:
+    resolution: {integrity: sha512-oxzHTEv6VPm3XXNaHPyUTTte+3wGv7qVQtqaZCrgstI16gCuhNOtBXLEBkBREP57YTd68P0VgDgG73jSD8bwXQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -582,8 +583,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.18.18:
-    resolution: {integrity: sha512-8Otf05Vx5sZjLLDulgr5QS5lsWXMplKZEyHMArH9/S4olLlhzmdhQBPhzhJTNwaL2FJNdWcUPNGAcoD5zDTfUA==}
+  /@esbuild/netbsd-x64@0.18.20:
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -591,8 +592,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.19.1:
-    resolution: {integrity: sha512-4OrGMPorHCq9h52VLtyyyAmPjC2ZlANx54VDYyCrqXUOi+k0qxnPKXKKprVES67w2mE7TZJx9qZmT+jHeiZbHQ==}
+  /@esbuild/netbsd-x64@0.19.2:
+    resolution: {integrity: sha512-WNa5zZk1XpTTwMDompZmvQLHszDDDN7lYjEHCUmAGB83Bgs20EMs7ICD+oKeT6xt4phV4NDdSi/8OfjPbSbZfQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -600,8 +601,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.18.18:
-    resolution: {integrity: sha512-tFiFF4kT5L5qhVrWJUNxEXWvvX8nK/UX9ZrB7apuTwY3f6+Xy4aFMBPwAVrBYtBd5MOUuyOVHK6HBZCAHkwUlw==}
+  /@esbuild/openbsd-x64@0.18.20:
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -609,8 +610,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.19.1:
-    resolution: {integrity: sha512-3a7ZYMjBC4P3FKdTmUZHJw7Mhzp71m+iSFFhX1PnLZ03qmyaB2K+vJZCk4PjRjAvm5lSupJQQtM/AFMyLgKlxQ==}
+  /@esbuild/openbsd-x64@0.19.2:
+    resolution: {integrity: sha512-S6kI1aT3S++Dedb7vxIuUOb3oAxqxk2Rh5rOXOTYnzN8JzW1VzBd+IqPiSpgitu45042SYD3HCoEyhLKQcDFDw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -618,8 +619,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.18.18:
-    resolution: {integrity: sha512-MPogVV8Bzh8os4OM+YDGGsSzCzmNRiyKGtHoJyZLtI4BMmd6EcxmGlcEGK1uM46h1BiOyi7Z7teUtzzQhvkC+w==}
+  /@esbuild/sunos-x64@0.18.20:
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -627,8 +628,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.19.1:
-    resolution: {integrity: sha512-29yWBN5XfEjXT8yoeVb8cXfN1jAQLB+uskog1vBMhFR+YWOYvsrwPnh4hspETC/JnF95J+iETrvxgOUlICTWIw==}
+  /@esbuild/sunos-x64@0.19.2:
+    resolution: {integrity: sha512-VXSSMsmb+Z8LbsQGcBMiM+fYObDNRm8p7tkUDMPG/g4fhFX5DEFmjxIEa3N8Zr96SjsJ1woAhF0DUnS3MF3ARw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -636,8 +637,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.18.18:
-    resolution: {integrity: sha512-YKD6LF/XXY9REu+ZL5RAsusiG48n602qxsMVh/E8FFD9hp4OyTQaL9fpE1ovxwQXqFio+tT0ITUGjDSSSPN13w==}
+  /@esbuild/win32-arm64@0.18.20:
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -645,8 +646,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.19.1:
-    resolution: {integrity: sha512-9Hb/WUXgyXlL55w3iNVyLkN9gq9x+agv3kk80foWbfpOwe7Qw4Vx6JGB+XQdsIfvvP1kShVQPIvBgVj0TxLlVw==}
+  /@esbuild/win32-arm64@0.19.2:
+    resolution: {integrity: sha512-5NayUlSAyb5PQYFAU9x3bHdsqB88RC3aM9lKDAz4X1mo/EchMIT1Q+pSeBXNgkfNmRecLXA0O8xP+x8V+g/LKg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -654,8 +655,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.18.18:
-    resolution: {integrity: sha512-NjSBmBsyZBTsZB6ga6rA6PfG/RHnwruUz/9YEVXcm4STGauFWvhYhOMhEyw1yU5NVgYYm8CH5AltCm77TS21/Q==}
+  /@esbuild/win32-ia32@0.18.20:
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -663,8 +664,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.19.1:
-    resolution: {integrity: sha512-VGdtEcXX/f01NgoM8emDnpdOyrZCQ7VTwLv89MOl3mvJ5fbCOBMNCa8t7RZS4lf12RS87qOuJFX7Bh9aLTbSxg==}
+  /@esbuild/win32-ia32@0.19.2:
+    resolution: {integrity: sha512-47gL/ek1v36iN0wL9L4Q2MFdujR0poLZMJwhO2/N3gA89jgHp4MR8DKCmwYtGNksbfJb9JoTtbkoe6sDhg2QTA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -672,8 +673,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.18.18:
-    resolution: {integrity: sha512-eTSg/gC3p3tdjj4roDhe5xu94l1s2jMazP8u2FsYO8SEKvSpPOO71EucprDn/IuErDPvTFUhV9lTw5z5WJCRKQ==}
+  /@esbuild/win32-x64@0.18.20:
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -681,8 +682,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.19.1:
-    resolution: {integrity: sha512-H6u8OHmJkKJubLbukVOyi9yA5lzK8VE4TFEkZj2vgusTUPvFeMQ8YnWviVc9F6PuKS6ZIpOvi2/sfiW8tQZQ2g==}
+  /@esbuild/win32-x64@0.19.2:
+    resolution: {integrity: sha512-tcuhV7ncXBqbt/Ybf0IyrMcwVOAPDckMK9rXNHtF17UTK18OKLpg08glminN06pt2WCoALhXdLfSPbVvK/6fxw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -690,29 +691,29 @@ packages:
     dev: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.46.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.48.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.46.0
-      eslint-visitor-keys: 3.4.2
+      eslint: 8.48.0
+      eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@eslint-community/regexpp@4.6.2:
-    resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
+  /@eslint-community/regexpp@4.8.0:
+    resolution: {integrity: sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
-  /@eslint/eslintrc@2.1.1:
-    resolution: {integrity: sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==}
+  /@eslint/eslintrc@2.1.2:
+    resolution: {integrity: sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.6.1
-      globals: 13.20.0
+      globals: 13.21.0
       ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -722,13 +723,13 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/js@8.46.0:
-    resolution: {integrity: sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==}
+  /@eslint/js@8.48.0:
+    resolution: {integrity: sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@humanwhocodes/config-array@0.11.10:
-    resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
+  /@humanwhocodes/config-array@0.11.11:
+    resolution: {integrity: sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -747,8 +748,8 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@jest/schemas@29.6.0:
-    resolution: {integrity: sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==}
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@sinclair/typebox': 0.27.8
@@ -794,7 +795,7 @@ packages:
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.22.11
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -803,7 +804,7 @@ packages:
   /@manypkg/get-packages@1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.22.11
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -841,7 +842,7 @@ packages:
       is-glob: 4.0.3
       open: 9.1.0
       picocolors: 1.0.0
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: true
 
   /@sinclair/typebox@0.27.8:
@@ -858,8 +859,8 @@ packages:
       - encoding
     dev: true
 
-  /@tsconfig/node18@18.2.0:
-    resolution: {integrity: sha512-yhxwIlFVSVcMym3O31HoMnRXpoenmpIxcj4Yoes2DUpe+xCJnA7ECQP1Vw889V0jTt/2nzvpLQ/UuMYCd3JPIg==}
+  /@tsconfig/node18@18.2.1:
+    resolution: {integrity: sha512-RDDZFuofwkcKpl8Vpj5wFbY+H53xOtqK7ckEL1sXsbPwvKwDdjQf3LkHbtt9sxIHn9nWIEwkmCwBRZ6z5TKU2A==}
     dev: true
 
   /@types/chai-subset@1.3.3:
@@ -892,58 +893,58 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node@20.4.8:
-    resolution: {integrity: sha512-0mHckf6D2DiIAzh8fM8f3HQCvMKDpK94YQ0DSVkfWTG9BZleYIWudw9cJxX8oCk9bM+vAkDyujDV6dmKHbvQpg==}
+  /@types/node@20.5.7:
+    resolution: {integrity: sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==}
     dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
 
-  /@types/semver@7.5.0:
-    resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
+  /@types/semver@7.5.1:
+    resolution: {integrity: sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==}
     dev: true
 
   /@types/unist@2.0.7:
     resolution: {integrity: sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==}
     dev: true
 
-  /@vitest/expect@0.34.1:
-    resolution: {integrity: sha512-q2CD8+XIsQ+tHwypnoCk8Mnv5e6afLFvinVGCq3/BOT4kQdVQmY6rRfyKkwcg635lbliLPqbunXZr+L1ssUWiQ==}
+  /@vitest/expect@0.34.3:
+    resolution: {integrity: sha512-F8MTXZUYRBVsYL1uoIft1HHWhwDbSzwAU9Zgh8S6WFC3YgVb4AnFV2GXO3P5Em8FjEYaZtTnQYoNwwBrlOMXgg==}
     dependencies:
-      '@vitest/spy': 0.34.1
-      '@vitest/utils': 0.34.1
-      chai: 4.3.7
+      '@vitest/spy': 0.34.3
+      '@vitest/utils': 0.34.3
+      chai: 4.3.8
     dev: true
 
-  /@vitest/runner@0.34.1:
-    resolution: {integrity: sha512-YfQMpYzDsYB7yqgmlxZ06NI4LurHWfrH7Wy3Pvf/z/vwUSgq1zLAb1lWcItCzQG+NVox+VvzlKQrYEXb47645g==}
+  /@vitest/runner@0.34.3:
+    resolution: {integrity: sha512-lYNq7N3vR57VMKMPLVvmJoiN4bqwzZ1euTW+XXYH5kzr3W/+xQG3b41xJn9ChJ3AhYOSoweu974S1V3qDcFESA==}
     dependencies:
-      '@vitest/utils': 0.34.1
+      '@vitest/utils': 0.34.3
       p-limit: 4.0.0
       pathe: 1.1.1
     dev: true
 
-  /@vitest/snapshot@0.34.1:
-    resolution: {integrity: sha512-0O9LfLU0114OqdF8lENlrLsnn024Tb1CsS9UwG0YMWY2oGTQfPtkW+B/7ieyv0X9R2Oijhi3caB1xgGgEgclSQ==}
+  /@vitest/snapshot@0.34.3:
+    resolution: {integrity: sha512-QyPaE15DQwbnIBp/yNJ8lbvXTZxS00kRly0kfFgAD5EYmCbYcA+1EEyRalc93M0gosL/xHeg3lKAClIXYpmUiQ==}
     dependencies:
-      magic-string: 0.30.2
+      magic-string: 0.30.3
       pathe: 1.1.1
-      pretty-format: 29.6.2
+      pretty-format: 29.6.3
     dev: true
 
-  /@vitest/spy@0.34.1:
-    resolution: {integrity: sha512-UT4WcI3EAPUNO8n6y9QoEqynGGEPmmRxC+cLzneFFXpmacivjHZsNbiKD88KUScv5DCHVDgdBsLD7O7s1enFcQ==}
+  /@vitest/spy@0.34.3:
+    resolution: {integrity: sha512-N1V0RFQ6AI7CPgzBq9kzjRdPIgThC340DGjdKdPSE8r86aUSmeliTUgkTqLSgtEwWWsGfBQ+UetZWhK0BgJmkQ==}
     dependencies:
       tinyspy: 2.1.1
     dev: true
 
-  /@vitest/utils@0.34.1:
-    resolution: {integrity: sha512-/ql9dsFi4iuEbiNcjNHQWXBum7aL8pyhxvfnD9gNtbjR9fUKAjxhj4AA3yfLXg6gJpMGGecvtF8Au2G9y3q47Q==}
+  /@vitest/utils@0.34.3:
+    resolution: {integrity: sha512-kiSnzLG6m/tiT0XEl4U2H8JDBjFtwVlaE8I3QfGiMFR0QvnRDfYfdP3YvTBWM/6iJDAyaPY6yVQiCTUc7ZzTHA==}
     dependencies:
-      diff-sequences: 29.4.3
+      diff-sequences: 29.6.3
       loupe: 2.3.6
-      pretty-format: 29.6.2
+      pretty-format: 29.6.3
     dev: true
 
   /acorn-jsx@5.3.2(acorn@8.10.0):
@@ -1171,8 +1172,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /chai@4.3.7:
-    resolution: {integrity: sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==}
+  /chai@4.3.8:
+    resolution: {integrity: sha512-vX4YvVVtxlfSZ2VecZgFUTU5qPCYsobVI2O9FmwEXBhDigYGQA6jRXCycIs1yJnnWbZ6/+a2zNIF5DfVCcJBFQ==}
     engines: {node: '>=4'}
     dependencies:
       assertion-error: 1.1.0
@@ -1434,8 +1435,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /diff-sequences@29.4.3:
-    resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
@@ -1458,8 +1459,8 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /dts-buddy@0.1.12:
-    resolution: {integrity: sha512-3HcUQnmG02fPSFL/Y1Ufh4oAGpaJ8cN4UP60Q1ll014LSwfS7XceMr7jBt9k55cT+dznZsQCxOx2tITgq/WHsw==}
+  /dts-buddy@0.2.4:
+    resolution: {integrity: sha512-41d7aGv2DXJYlzeKSKHf0GtpCC8OdpEHhz+aqjylKV5aP3fl4APzNmQ5hL5vSKZMaO/lrkrKWC+HQrxl+mcgUw==}
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.5
@@ -1467,11 +1468,11 @@ packages:
       globrex: 0.1.2
       kleur: 4.1.5
       locate-character: 3.0.0
-      magic-string: 0.30.2
+      magic-string: 0.30.3
       sade: 1.8.1
       tiny-glob: 0.2.9
-      ts-api-utils: 0.0.46(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-api-utils: 1.0.2(typescript@5.0.4)
+      typescript: 5.0.4
     dev: true
 
   /eastasianwidth@0.2.0:
@@ -1510,7 +1511,7 @@ packages:
       call-bind: 1.0.2
       es-set-tostringtag: 2.0.1
       es-to-primitive: 1.2.1
-      function.prototype.name: 1.1.5
+      function.prototype.name: 1.1.6
       get-intrinsic: 1.2.1
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
@@ -1569,64 +1570,64 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
-  /esbuild@0.18.18:
-    resolution: {integrity: sha512-UckDPWvdVJLNT0npk5AMTpVwGRQhS76rWFLmHwEtgNvWlR9sgVV1eyc/oeBtM86q9s8ABBLMmm0CwNxhVemOiw==}
+  /esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.18.18
-      '@esbuild/android-arm64': 0.18.18
-      '@esbuild/android-x64': 0.18.18
-      '@esbuild/darwin-arm64': 0.18.18
-      '@esbuild/darwin-x64': 0.18.18
-      '@esbuild/freebsd-arm64': 0.18.18
-      '@esbuild/freebsd-x64': 0.18.18
-      '@esbuild/linux-arm': 0.18.18
-      '@esbuild/linux-arm64': 0.18.18
-      '@esbuild/linux-ia32': 0.18.18
-      '@esbuild/linux-loong64': 0.18.18
-      '@esbuild/linux-mips64el': 0.18.18
-      '@esbuild/linux-ppc64': 0.18.18
-      '@esbuild/linux-riscv64': 0.18.18
-      '@esbuild/linux-s390x': 0.18.18
-      '@esbuild/linux-x64': 0.18.18
-      '@esbuild/netbsd-x64': 0.18.18
-      '@esbuild/openbsd-x64': 0.18.18
-      '@esbuild/sunos-x64': 0.18.18
-      '@esbuild/win32-arm64': 0.18.18
-      '@esbuild/win32-ia32': 0.18.18
-      '@esbuild/win32-x64': 0.18.18
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
     dev: true
 
-  /esbuild@0.19.1:
-    resolution: {integrity: sha512-IknHHwV4B/H4imOAu+416fuCvPfRjdncoyGi7eunhSvHuHkdNs50sLWan2LEG2Mym07TuW6gJUIyRS9G1miHEg==}
+  /esbuild@0.19.2:
+    resolution: {integrity: sha512-G6hPax8UbFakEj3hWO0Vs52LQ8k3lnBhxZWomUJDxfz3rZTLqF5k/FCzuNdLx2RbpBiQQF9H9onlDDH1lZsnjg==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.19.1
-      '@esbuild/android-arm64': 0.19.1
-      '@esbuild/android-x64': 0.19.1
-      '@esbuild/darwin-arm64': 0.19.1
-      '@esbuild/darwin-x64': 0.19.1
-      '@esbuild/freebsd-arm64': 0.19.1
-      '@esbuild/freebsd-x64': 0.19.1
-      '@esbuild/linux-arm': 0.19.1
-      '@esbuild/linux-arm64': 0.19.1
-      '@esbuild/linux-ia32': 0.19.1
-      '@esbuild/linux-loong64': 0.19.1
-      '@esbuild/linux-mips64el': 0.19.1
-      '@esbuild/linux-ppc64': 0.19.1
-      '@esbuild/linux-riscv64': 0.19.1
-      '@esbuild/linux-s390x': 0.19.1
-      '@esbuild/linux-x64': 0.19.1
-      '@esbuild/netbsd-x64': 0.19.1
-      '@esbuild/openbsd-x64': 0.19.1
-      '@esbuild/sunos-x64': 0.19.1
-      '@esbuild/win32-arm64': 0.19.1
-      '@esbuild/win32-ia32': 0.19.1
-      '@esbuild/win32-x64': 0.19.1
+      '@esbuild/android-arm': 0.19.2
+      '@esbuild/android-arm64': 0.19.2
+      '@esbuild/android-x64': 0.19.2
+      '@esbuild/darwin-arm64': 0.19.2
+      '@esbuild/darwin-x64': 0.19.2
+      '@esbuild/freebsd-arm64': 0.19.2
+      '@esbuild/freebsd-x64': 0.19.2
+      '@esbuild/linux-arm': 0.19.2
+      '@esbuild/linux-arm64': 0.19.2
+      '@esbuild/linux-ia32': 0.19.2
+      '@esbuild/linux-loong64': 0.19.2
+      '@esbuild/linux-mips64el': 0.19.2
+      '@esbuild/linux-ppc64': 0.19.2
+      '@esbuild/linux-riscv64': 0.19.2
+      '@esbuild/linux-s390x': 0.19.2
+      '@esbuild/linux-x64': 0.19.2
+      '@esbuild/netbsd-x64': 0.19.2
+      '@esbuild/openbsd-x64': 0.19.2
+      '@esbuild/sunos-x64': 0.19.2
+      '@esbuild/win32-arm64': 0.19.2
+      '@esbuild/win32-ia32': 0.19.2
+      '@esbuild/win32-x64': 0.19.2
     dev: true
 
   /escalade@3.1.1:
@@ -1644,48 +1645,48 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-prettier@8.10.0(eslint@8.46.0):
-    resolution: {integrity: sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==}
+  /eslint-config-prettier@9.0.0(eslint@8.48.0):
+    resolution: {integrity: sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.46.0
+      eslint: 8.48.0
     dev: true
 
-  /eslint-plugin-es-x@7.2.0(eslint@8.46.0):
+  /eslint-plugin-es-x@7.2.0(eslint@8.48.0):
     resolution: {integrity: sha512-9dvv5CcvNjSJPqnS5uZkqb3xmbeqRLnvXKK7iI5+oK/yTusyc46zbBZKENGsOfojm/mKfszyZb+wNqNPAPeGXA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=8'
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.46.0)
-      '@eslint-community/regexpp': 4.6.2
-      eslint: 8.46.0
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.48.0)
+      '@eslint-community/regexpp': 4.8.0
+      eslint: 8.48.0
     dev: true
 
-  /eslint-plugin-markdown@3.0.1(eslint@8.46.0):
+  /eslint-plugin-markdown@3.0.1(eslint@8.48.0):
     resolution: {integrity: sha512-8rqoc148DWdGdmYF6WSQFT3uQ6PO7zXYgeBpHAOAakX/zpq+NvFYbDA/H7PYzHajwtmaOzAwfxyl++x0g1/N9A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.46.0
+      eslint: 8.48.0
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-n@16.0.1(eslint@8.46.0):
-    resolution: {integrity: sha512-CDmHegJN0OF3L5cz5tATH84RPQm9kG+Yx39wIqIwPR2C0uhBGMWfbbOtetR83PQjjidA5aXMu+LEFw1jaSwvTA==}
+  /eslint-plugin-n@16.0.2(eslint@8.48.0):
+    resolution: {integrity: sha512-Y66uDfUNbBzypsr0kELWrIz+5skicECrLUqlWuXawNSLUq3ltGlCwu6phboYYOTSnoTdHgTLrc+5Ydo6KjzZog==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.46.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.48.0)
       builtins: 5.0.1
-      eslint: 8.46.0
-      eslint-plugin-es-x: 7.2.0(eslint@8.46.0)
+      eslint: 8.48.0
+      eslint-plugin-es-x: 7.2.0(eslint@8.48.0)
       ignore: 5.2.4
       is-core-module: 2.13.0
       minimatch: 3.1.2
@@ -1693,7 +1694,7 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /eslint-plugin-prettier@5.0.0(eslint-config-prettier@8.10.0)(eslint@8.46.0)(prettier@3.0.1):
+  /eslint-plugin-prettier@5.0.0(eslint-config-prettier@9.0.0)(eslint@8.48.0)(prettier@3.0.3):
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -1707,9 +1708,9 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      eslint: 8.46.0
-      eslint-config-prettier: 8.10.0(eslint@8.46.0)
-      prettier: 3.0.1
+      eslint: 8.48.0
+      eslint-config-prettier: 9.0.0(eslint@8.48.0)
+      prettier: 3.0.3
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.5
     dev: true
@@ -1722,21 +1723,21 @@ packages:
       estraverse: 5.3.0
     dev: true
 
-  /eslint-visitor-keys@3.4.2:
-    resolution: {integrity: sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==}
+  /eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint@8.46.0:
-    resolution: {integrity: sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==}
+  /eslint@8.48.0:
+    resolution: {integrity: sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.46.0)
-      '@eslint-community/regexpp': 4.6.2
-      '@eslint/eslintrc': 2.1.1
-      '@eslint/js': 8.46.0
-      '@humanwhocodes/config-array': 0.11.10
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.48.0)
+      '@eslint-community/regexpp': 4.8.0
+      '@eslint/eslintrc': 2.1.2
+      '@eslint/js': 8.48.0
+      '@humanwhocodes/config-array': 0.11.11
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6
@@ -1746,7 +1747,7 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.2
+      eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.5.0
       esutils: 2.0.3
@@ -1754,7 +1755,7 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.20.0
+      globals: 13.21.0
       graphemer: 1.4.0
       ignore: 5.2.4
       imurmurhash: 0.1.4
@@ -1779,7 +1780,7 @@ packages:
     dependencies:
       acorn: 8.10.0
       acorn-jsx: 5.3.2(acorn@8.10.0)
-      eslint-visitor-keys: 3.4.2
+      eslint-visitor-keys: 3.4.3
     dev: true
 
   /esprima@4.0.1:
@@ -1896,7 +1897,7 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      flat-cache: 3.0.4
+      flat-cache: 3.1.0
     dev: true
 
   /fill-range@7.0.1:
@@ -1929,11 +1930,12 @@ packages:
       pkg-dir: 4.2.0
     dev: true
 
-  /flat-cache@3.0.4:
-    resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /flat-cache@3.1.0:
+    resolution: {integrity: sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==}
+    engines: {node: '>=12.0.0'}
     dependencies:
       flatted: 3.2.7
+      keyv: 4.5.3
       rimraf: 3.0.2
     dev: true
 
@@ -1969,8 +1971,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -1981,8 +1983,8 @@ packages:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
     dev: true
 
-  /function.prototype.name@1.1.5:
-    resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
+  /function.prototype.name@1.1.6:
+    resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -2062,8 +2064,8 @@ packages:
       once: 1.4.0
     dev: true
 
-  /globals@13.20.0:
-    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
+  /globals@13.21.0:
+    resolution: {integrity: sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -2474,6 +2476,10 @@ packages:
       argparse: 2.0.1
     dev: true
 
+  /json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
+
   /json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
     dev: true
@@ -2498,6 +2504,12 @@ packages:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
       graceful-fs: 4.2.11
+    dev: true
+
+  /keyv@4.5.3:
+    resolution: {integrity: sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==}
+    dependencies:
+      json-buffer: 3.0.1
     dev: true
 
   /kind-of@6.0.3:
@@ -2527,8 +2539,8 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
-  /lint-staged@14.0.0:
-    resolution: {integrity: sha512-0tLf0pqZYkar/wu3nTctk4rVIG+d7PanDYv4/IQR4qwdqfQkTDziLRFnqMcLuLBTuUqmcLwsHPD2EjQ18d/oaA==}
+  /lint-staged@14.0.1:
+    resolution: {integrity: sha512-Mw0cL6HXnHN1ag0mN/Dg4g6sr8uf8sn98w2Oc1ECtFto9tvRF7nkXGJRbx8gPlHyoR0pLyBr2lQHbWwmUHe1Sw==}
     engines: {node: ^16.14.0 || >=18.0.0}
     hasBin: true
     dependencies:
@@ -2646,8 +2658,8 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /magic-string@0.30.2:
-    resolution: {integrity: sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==}
+  /magic-string@0.30.3:
+    resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -2769,13 +2781,13 @@ packages:
     engines: {node: '>= 8.0.0'}
     dev: true
 
-  /mlly@1.4.0:
-    resolution: {integrity: sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==}
+  /mlly@1.4.1:
+    resolution: {integrity: sha512-SCDs78Q2o09jiZiE2WziwVBEqXQ02XkGdUy45cbJf+BpYRIjArXRJ1Wbowxkb+NaM9DWvS3UC9GiO/6eqvQ/pg==}
     dependencies:
       acorn: 8.10.0
       pathe: 1.1.1
       pkg-types: 1.0.3
-      ufo: 1.2.0
+      ufo: 1.3.0
     dev: true
 
   /mri@1.2.0:
@@ -2801,8 +2813,8 @@ packages:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
 
-  /node-fetch@2.6.12:
-    resolution: {integrity: sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==}
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -3027,7 +3039,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.22.13
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -3124,12 +3136,12 @@ packages:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
       jsonc-parser: 3.2.0
-      mlly: 1.4.0
+      mlly: 1.4.1
       pathe: 1.1.1
     dev: true
 
-  /postcss@8.4.27:
-    resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
+  /postcss@8.4.29:
+    resolution: {integrity: sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.6
@@ -3165,17 +3177,17 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier@3.0.1:
-    resolution: {integrity: sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==}
+  /prettier@3.0.3:
+    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true
 
-  /pretty-format@29.6.2:
-    resolution: {integrity: sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==}
+  /pretty-format@29.6.3:
+    resolution: {integrity: sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/schemas': 29.6.0
+      '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.2.0
     dev: true
@@ -3184,8 +3196,8 @@ packages:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: true
 
-  /publint@0.2.0:
-    resolution: {integrity: sha512-h8lxdjhQjpDw+A4BgY4sE7Z4CU3x5tCGGpERVdKGDQmWMtr1P7kvptJS2P10HhmNnS7Yeny37zfQE5+xRZ6nig==}
+  /publint@0.2.2:
+    resolution: {integrity: sha512-2t2IO6Y8Z+QBNLG89bpRhTQH7Ifn/83Kr0dVVdmOybq7GAT6+M4YGZd5AhtfMJbYPmbT7YD469pDKLCK94Q2+Q==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
@@ -3258,8 +3270,8 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /regenerator-runtime@0.13.11:
-    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+  /regenerator-runtime@0.14.0:
+    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
     dev: true
 
   /regexp.prototype.flags@1.5.0:
@@ -3323,12 +3335,12 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup@3.27.2:
-    resolution: {integrity: sha512-YGwmHf7h2oUHkVBT248x0yt6vZkYQ3/rvE5iQuVBh3WO8GcJ6BNeOkpoX1yMHIiBm18EMLjBPIoUDkhgnyxGOQ==}
+  /rollup@3.28.1:
+    resolution: {integrity: sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /run-applescript@5.0.0:
@@ -3502,8 +3514,8 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
-  /std-env@3.3.3:
-    resolution: {integrity: sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==}
+  /std-env@3.4.3:
+    resolution: {integrity: sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==}
     dev: true
 
   /stream-transform@2.1.3:
@@ -3640,7 +3652,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/utils': 2.4.2
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: true
 
   /term-size@2.2.1:
@@ -3701,17 +3713,17 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-api-utils@0.0.46(typescript@5.1.6):
-    resolution: {integrity: sha512-YKJeSx39n0mMk+hrpyHKyTgxA3s7Pz/j1cXYR+t8HcwwZupzOR5xDGKnOEw3gmLaUeFUQt3FJD39AH9Ajn/mdA==}
+  /ts-api-utils@1.0.2(typescript@5.0.4):
+    resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.1.6
+      typescript: 5.0.4
     dev: true
 
-  /tslib@2.6.1:
-    resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
+  /tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
 
   /tty-table@4.2.1:
@@ -3803,14 +3815,20 @@ packages:
       is-typed-array: 1.1.12
     dev: true
 
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+  /typescript@5.0.4:
+    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
+    engines: {node: '>=12.20'}
+    hasBin: true
+    dev: true
+
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
 
-  /ufo@1.2.0:
-    resolution: {integrity: sha512-RsPyTbqORDNDxqAdQPQBpgqhWle1VcTSou/FraClYlHf6TZnQcGslpLcAphNR+sQW4q5lLWLbOsRlh9j24baQg==}
+  /ufo@1.3.0:
+    resolution: {integrity: sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==}
     dev: true
 
   /unbox-primitive@1.0.2:
@@ -3851,17 +3869,17 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@0.34.1(@types/node@20.4.8):
-    resolution: {integrity: sha512-odAZAL9xFMuAg8aWd7nSPT+hU8u2r9gU3LRm9QKjxBEF2rRdWpMuqkrkjvyVQEdNFiBctqr2Gg4uJYizm5Le6w==}
+  /vite-node@0.34.3(@types/node@20.5.7):
+    resolution: {integrity: sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
-      mlly: 1.4.0
+      mlly: 1.4.1
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.8(@types/node@20.4.8)
+      vite: 4.4.9(@types/node@20.5.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -3873,8 +3891,8 @@ packages:
       - terser
     dev: true
 
-  /vite@4.4.8(@types/node@20.4.8):
-    resolution: {integrity: sha512-LONawOUUjxQridNWGQlNizfKH89qPigK36XhMI7COMGztz8KNY0JHim7/xDd71CZwGT4HtSRgI7Hy+RlhG0Gvg==}
+  /vite@4.4.9(@types/node@20.5.7):
+    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -3901,16 +3919,16 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.4.8
-      esbuild: 0.18.18
-      postcss: 8.4.27
-      rollup: 3.27.2
+      '@types/node': 20.5.7
+      esbuild: 0.18.20
+      postcss: 8.4.29
+      rollup: 3.28.1
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
-  /vitest@0.34.1:
-    resolution: {integrity: sha512-G1PzuBEq9A75XSU88yO5G4vPT20UovbC/2osB2KEuV/FisSIIsw7m5y2xMdB7RsAGHAfg2lPmp2qKr3KWliVlQ==}
+  /vitest@0.34.3:
+    resolution: {integrity: sha512-7+VA5Iw4S3USYk+qwPxHl8plCMhA5rtfwMjgoQXMT7rO5ldWcdsdo3U1QD289JgglGK4WeOzgoLTsGFu6VISyQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     peerDependencies:
@@ -3942,27 +3960,27 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 20.4.8
-      '@vitest/expect': 0.34.1
-      '@vitest/runner': 0.34.1
-      '@vitest/snapshot': 0.34.1
-      '@vitest/spy': 0.34.1
-      '@vitest/utils': 0.34.1
+      '@types/node': 20.5.7
+      '@vitest/expect': 0.34.3
+      '@vitest/runner': 0.34.3
+      '@vitest/snapshot': 0.34.3
+      '@vitest/spy': 0.34.3
+      '@vitest/utils': 0.34.3
       acorn: 8.10.0
       acorn-walk: 8.2.0
       cac: 6.7.14
-      chai: 4.3.7
+      chai: 4.3.8
       debug: 4.3.4
       local-pkg: 0.4.3
-      magic-string: 0.30.2
+      magic-string: 0.30.3
       pathe: 1.1.1
       picocolors: 1.0.0
-      std-env: 3.3.3
+      std-env: 3.4.3
       strip-literal: 1.3.0
       tinybench: 2.5.0
       tinypool: 0.7.0
-      vite: 4.4.8(@types/node@20.4.8)
-      vite-node: 0.34.1(@types/node@20.4.8)
+      vite: 4.4.9(@types/node@20.5.7)
+      vite-node: 0.34.3(@types/node@20.5.7)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -55,7 +55,6 @@ const blockHeadings = {
 const order = Object.keys(blockHeadings);
 
 function sortBlocks(a, b) {
-	console.log('xxx', a.title, b.title);
 	const aIndex = order.indexOf(a.title);
 	const bIndex = order.indexOf(b.title);
 	if (aIndex < 0) {

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -5,10 +5,21 @@ import fs from 'fs';
 
 const header = '<!-- generated, do not modify -->\n## API \n\n';
 
-function toMD(block) {
-	const title = block.match(/(?:function|class|interface) ([a-zA-Z]+)/)[1];
-	return '### ' + title + '\n\n```ts\n' + block + '\n```';
+function parseBlock(block) {
+	// eslint-disable-next-line no-unused-vars
+	const [_, kind, title] = block.match(/(function|class|interface) ([a-zA-Z]+)/);
+	const heading = '#'.repeat(blockHeadings[title] || 3);
+	return {
+		kind,
+		title,
+		md: heading + ' ' + title + '\n\n```ts\n' + stripPrivate(block) + '\n```'
+	};
 }
+
+function stripPrivate(str) {
+	return str.replace(/^\s*#?private[; ].*\n?/gm, '');
+}
+
 const typesFile = 'packages/tsconfck/types/index.d.ts';
 const blockSeparator = '\n-- cut here --\n';
 let dts = fs
@@ -24,6 +35,45 @@ const blocks = dts
 	.map((b) => b.trim())
 	.filter(Boolean);
 
-const md = header + blocks.map((block) => toMD(block)).join('\n\n') + '\n';
+const blockHeadings = {
+	find: 3,
+	TSConfckFindOptions: 4,
+	parse: 3,
+	TSConfckParseOptions: 4,
+	TSConfckParseResult: 4,
+	TSConfckParseError: 4,
+	findNative: 3,
+	parseNative: 3,
+	TSConfckParseNativeOptions: 4,
+	TSConfckParseNativeResult: 4,
+	TSConfckParseNativeError: 4,
+	findAll: 3,
+	TSConfckFindAllOptions: 4,
+	toJson: 3,
+	TSConfckCache: 3
+};
+const order = Object.keys(blockHeadings);
+
+function sortBlocks(a, b) {
+	console.log('xxx', a.title, b.title);
+	const aIndex = order.indexOf(a.title);
+	const bIndex = order.indexOf(b.title);
+	if (aIndex < 0) {
+		console.log('misssing title order: ', a.title);
+	}
+	if (bIndex < 0) {
+		console.log('misssing title order: ', b.title);
+	}
+	return aIndex - bIndex;
+}
+
+const md =
+	header +
+	blocks
+		.map((block) => parseBlock(block))
+		.sort(sortBlocks)
+		.map((b) => b.md)
+		.join('\n\n') +
+	'\n';
 fs.writeFileSync('docs/api.md', md);
 console.log(`generated docs/api.md from ${typesFile}`);

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -7,7 +7,7 @@ const header = '<!-- generated, do not modify -->\n## API \n\n';
 
 function parseBlock(block) {
 	// eslint-disable-next-line no-unused-vars
-	const [_, kind, title] = block.match(/(function|class|interface) ([a-zA-Z]+)/);
+	const [_, kind, title] = block.match(/(function|class|interface|type) ([a-zA-Z]+)/);
 	const heading = '#'.repeat(blockHeadings[title] || 3);
 	return {
 		kind,
@@ -50,7 +50,8 @@ const blockHeadings = {
 	findAll: 3,
 	TSConfckFindAllOptions: 4,
 	toJson: 3,
-	TSConfckCache: 3
+	TSConfckCache: 3,
+	Awaitable: 3
 };
 const order = Object.keys(blockHeadings);
 


### PR DESCRIPTION
used in findNative/parseNative as well.

Main motivation behind this is that the previous way to use findAll + tsconfigPaths could create a lot of extra work in huge projects, where ts files were contained in a small subtree.

Without having to traverse all of root and lazily caching all directories that have been traversed, this costs a little bit more memory, but less up front work.

Example for tsconfig in  /a/b/c/tsconfig.json
```js
const cache = new TSConfckCache(); 
const eConfig = await find('/a/b/c/d/e/foo.ts',{cache}); //  traverses e,d,c  to find the config and adds all to the cache separately
const dConfig = await find('/a/b/c/d/foo.ts',{cache}); // no traversal needed, cache hit
const fConfig = await find('/a/b/c/d/e/f/foo.ts',{cache});  // only traverse from f to e, then finds cache hit
```

(findNative caching is a little bit less effective as cache hits during traversal are impossible)

In a very large project with deep code trees and many directories, this can consume extra memory because all intermediate directories are added to the cache separately.