### PR TITLE
fix: masquerading as esm in cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },


### PR DESCRIPTION

See https://arethetypeswrong.github.io/?p=tsconfck%402.1.2

<img width="763" alt="image" src="https://github.com/dominikg/tsconfck/assets/8111351/c10c876d-1b7a-4586-97e9-ff1855ca1461">

And this can be fixed in tsup 7.1.0 
https://github.com/egoist/tsup/pull/934#issue-1770253995

After remove types field, the result is
<img width="424" alt="image" src="https://github.com/dominikg/tsconfck/assets/8111351/354dbe0b-4212-42cb-89c3-dd4f072723de">
