### PR TITLE
fix: prevent deadlock with cache

### DIFF
--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/src/foo.ts
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/src/foo.ts
@@ -1,0 +1,3 @@
+export function foo() {
+	return 'foo';
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/src/tsconfig.src.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/src/tsconfig.src.json
@@ -1,0 +1,8 @@
+{
+  "include": ["./foo.ts"],
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "strict": true
+  }
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tests/foo.test.ts
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tests/foo.test.ts
@@ -1,0 +1,9 @@
+import { foo } from '../src/foo';
+import * as assert from 'assert';
+
+function test() {
+	const actual = foo();
+	const expected = 'foo';
+	assert.strictEqual(actual, expected);
+}
+test();

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tests/tsconfig.test.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tests/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "include": ["./*.test.ts"],
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "strict": false
+  }
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tsconfig.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "references": [
+    {"path": "./src/tsconfig.src.json"},
+    {"path": "./tests/tsconfig.test.json"}
+  ]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.base.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.base.json.tsconfig.parse.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.json.tsconfig.parse.json
@@ -1,0 +1,19 @@
+{
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./jsconfig.src.json"
+		},
+		{
+			"path": "./jsconfig.test.json"
+		}
+	],
+	"compilerOptions": {
+		"allowJs": true,
+		"maxNodeModuleJsDepth": 2,
+		"allowSyntheticDefaultImports": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.src.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.src.json.tsconfig.parse.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./jsconfig.base",
+	"include": [
+		"src/**/*"
+	],
+	"exclude": [
+		"src/**/*.spec.js"
+	],
+	"compilerOptions": {
+		"strict": true,
+		"allowJs": true,
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.test.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.test.json.tsconfig.parse.json
@@ -1,0 +1,12 @@
+{
+	"extends": "./jsconfig.base",
+	"include": [
+		"src/**/*.spec.js"
+	],
+	"compilerOptions": {
+		"strict": false,
+		"allowJs": true,
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.base.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.base.json.tsconfig.parse.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.src.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.src.json.tsconfig.parse.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./tsconfig.base",
+	"include": [
+		"src/**/*"
+	],
+	"exclude": [
+		"src/**/*.spec.ts"
+	],
+	"compilerOptions": {
+		"strict": true,
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.test.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.test.json.tsconfig.parse.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.base",
+	"include": [
+		"src/**/*.spec.ts"
+	],
+	"compilerOptions": {
+		"strict": false,
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse-native.ignore-files.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse-native.ignore-files.json
@@ -1,0 +1,12 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	],
+	"files": [],
+	"include": []
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse-native.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/tsconfig.src.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/tsconfig.src.json.tsconfig.parse.json
@@ -1,0 +1,10 @@
+{
+	"include": [
+		"./foo.ts"
+	],
+	"extends": "../tsconfig",
+	"compilerOptions": {
+		"composite": true,
+		"strict": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse-native.ignore-files.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse-native.ignore-files.json
@@ -1,0 +1,12 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	],
+	"files": [],
+	"include": []
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse-native.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/tsconfig.test.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/tsconfig.test.json.tsconfig.parse.json
@@ -1,0 +1,10 @@
+{
+	"include": [
+		"./*.test.ts"
+	],
+	"extends": "../tsconfig",
+	"compilerOptions": {
+		"composite": true,
+		"strict": false
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tsconfig.json.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tsconfig.json.parse-native.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tsconfig.json.parse.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}


### PR DESCRIPTION
fix #154 

This PR only adds a failing test sample for now, still unclear how to prevent this without reducing cache usage
