### PR TITLE
fix: add a temporary property '_isRootFile_' for each promise result of cache to prevent i…

### DIFF
--- a/.changeset/two-feet-heal.md
+++ b/.changeset/two-feet-heal.md
@@ -1,0 +1,5 @@
+---
+'tsconfck': patch
+---
+
+fix deadlock when referenced tsconfig extends original

--- a/docs/api.md
+++ b/docs/api.md
@@ -308,5 +308,8 @@ export class TSConfckCache<T> {
 	 * @throws {unknown} if cached value is an error
 	 */
 	getParseResult(file: string): Promise<T> | T;
+	/**
+	 * @param isRootFile a flag to check if current file which involking the parse() api, used to distinguish the normal cache which only parsed by parseFile()
+	 * */
 }
 ```

--- a/packages/tsconfck/src/cache.js
+++ b/packages/tsconfck/src/cache.js
@@ -63,9 +63,17 @@ export class TSConfckCache {
 	 * @internal
 	 * @private
 	 * @param file
+	 * @param {boolean} isRootFile a flag to check if current file which involking the parse() api, used to distinguish the normal cache which only parsed by parseFile()
 	 * @param {Promise<T>} result
 	 */
-	setParseResult(file, result) {
+	setParseResult(file, result, isRootFile = false) {
+		// _isRootFile_ is a temporary property for Promise result, used to prevent deadlock with cache
+		Object.defineProperty(result, '_isRootFile_', {
+			value: isRootFile,
+			writable: true,
+			enumerable: false,
+			configurable: true
+		});
 		this.#parsed.set(file, result);
 		result
 			.then((parsed) => {

--- a/packages/tsconfck/src/cache.js
+++ b/packages/tsconfck/src/cache.js
@@ -70,9 +70,9 @@ export class TSConfckCache {
 		// _isRootFile_ is a temporary property for Promise result, used to prevent deadlock with cache
 		Object.defineProperty(result, '_isRootFile_', {
 			value: isRootFile,
-			writable: true,
+			writable: false,
 			enumerable: false,
-			configurable: true
+			configurable: false
 		});
 		this.#parsed.set(file, result);
 		result

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/src/foo.ts
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/src/foo.ts
@@ -1,0 +1,3 @@
+export function foo() {
+	return 'foo';
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/src/tsconfig.src.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/src/tsconfig.src.json
@@ -1,0 +1,8 @@
+{
+  "include": ["./foo.ts"],
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "strict": true
+  }
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tests/foo.test.ts
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tests/foo.test.ts
@@ -1,0 +1,9 @@
+import { foo } from '../src/foo';
+import * as assert from 'assert';
+
+function test() {
+	const actual = foo();
+	const expected = 'foo';
+	assert.strictEqual(actual, expected);
+}
+test();

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tests/tsconfig.test.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tests/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "include": ["./*.test.ts"],
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "strict": false
+  }
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tsconfig.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-extends-original/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "references": [
+    {"path": "./src/tsconfig.src.json"},
+    {"path": "./tests/tsconfig.test.json"}
+  ]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.base.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.base.json.tsconfig.parse.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.json.tsconfig.parse.json
@@ -1,0 +1,19 @@
+{
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./jsconfig.src.json"
+		},
+		{
+			"path": "./jsconfig.test.json"
+		}
+	],
+	"compilerOptions": {
+		"allowJs": true,
+		"maxNodeModuleJsDepth": 2,
+		"allowSyntheticDefaultImports": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.src.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.src.json.tsconfig.parse.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./jsconfig.base",
+	"include": [
+		"src/**/*"
+	],
+	"exclude": [
+		"src/**/*.spec.js"
+	],
+	"compilerOptions": {
+		"strict": true,
+		"allowJs": true,
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.test.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/jsconfig/jsconfig.test.json.tsconfig.parse.json
@@ -1,0 +1,12 @@
+{
+	"extends": "./jsconfig.base",
+	"include": [
+		"src/**/*.spec.js"
+	],
+	"compilerOptions": {
+		"strict": false,
+		"allowJs": true,
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.base.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.base.json.tsconfig.parse.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.src.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.src.json.tsconfig.parse.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./tsconfig.base",
+	"include": [
+		"src/**/*"
+	],
+	"exclude": [
+		"src/**/*.spec.ts"
+	],
+	"compilerOptions": {
+		"strict": true,
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.test.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/mixed/tsconfig.test.json.tsconfig.parse.json
@@ -1,0 +1,11 @@
+{
+	"extends": "./tsconfig.base",
+	"include": [
+		"src/**/*.spec.ts"
+	],
+	"compilerOptions": {
+		"strict": false,
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse-native.ignore-files.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse-native.ignore-files.json
@@ -1,0 +1,12 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	],
+	"files": [],
+	"include": []
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse-native.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/foo.ts.tsconfig.parse.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/tsconfig.src.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/src/tsconfig.src.json.tsconfig.parse.json
@@ -1,0 +1,10 @@
+{
+	"include": [
+		"./foo.ts"
+	],
+	"extends": "../tsconfig",
+	"compilerOptions": {
+		"composite": true,
+		"strict": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse-native.ignore-files.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse-native.ignore-files.json
@@ -1,0 +1,12 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	],
+	"files": [],
+	"include": []
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse-native.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/foo.test.ts.tsconfig.parse.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/tsconfig.test.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tests/tsconfig.test.json.tsconfig.parse.json
@@ -1,0 +1,10 @@
+{
+	"include": [
+		"./*.test.ts"
+	],
+	"extends": "../tsconfig",
+	"compilerOptions": {
+		"composite": true,
+		"strict": false
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tsconfig.json.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tsconfig.json.parse-native.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-extends-original/tsconfig.json.parse.json
@@ -1,0 +1,10 @@
+{
+	"references": [
+		{
+			"path": "./src/tsconfig.src.json"
+		},
+		{
+			"path": "./tests/tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/simple/tsconfig.base.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/simple/tsconfig.base.json.tsconfig.parse.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"composite": true,
+		"strictNullChecks": true
+	}
+}

--- a/packages/tsconfck/types/index.d.ts
+++ b/packages/tsconfck/types/index.d.ts
@@ -55,7 +55,9 @@ declare module 'tsconfck' {
 		 * @throws {unknown} if cached value is an error
 		 */
 		getParseResult(file: string): Promise<T> | T;
-		
+		/**
+		 * @param isRootFile a flag to check if current file which involking the parse() api, used to distinguish the normal cache which only parsed by parseFile()
+		 * */
 		private setParseResult;
 		
 		private setConfigPath;

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -38,5 +38,5 @@
 		null,
 		null
 	],
-	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCYJC,OAAOA;;;;;;;iBCTbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCXnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC0BJC,KAAKA;cAoVdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCpVTC,WAAWA;cA6NpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;WCtPpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAkCnBC,oBAAoBA;;;;WAIpBC,sBAAsBA;;;;;;;;;;;;;;;WAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
+	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCYJC,OAAOA;;;;;;;iBCTbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCXnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC0BJC,KAAKA;cA2VdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC3VTC,WAAWA;cA6NpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;WCtPpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAkCnBC,oBAAoBA;;;;WAIpBC,sBAAsBA;;;;;;;;;;;;;;;WAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
 }


### PR DESCRIPTION
I've just came across the issue of https://github.com/vitest-dev/vitest/issues/5182. Then found out the RC is https://github.com/dominikg/tsconfck/issues/154. So I spent some times to read relevant codes and put my correction out to try to push this issue forward. The tests based on https://github.com/dominikg/tsconfck/pull/157.

My considerations about this fix: this fix is  based on the current design and as few changes as possible to just add a patch to prevent into the deadlock situation you've described in https://github.com/aleclarson/vite-tsconfig-paths/issues/132#issuecomment-1902718694. 

In the correction, I add an internal property `_isRootFile_` for each cached file and this new property means if the file is invoked by the public api `parese()` which used to distingust another type of cache which created by `parseFile()`. Then using `_isRootFile_` prevent into the deadlock in `parseFile()`.

@dominikg let me know if you have some comments.