### PR TITLE
Fix typescript 5.5 parse for configDir

### DIFF
--- a/.changeset/cyan-pumas-dream.md
+++ b/.changeset/cyan-pumas-dream.md
@@ -1,0 +1,5 @@
+---
+'tsconfck': patch
+---
+
+Fix ts 5.5 `${configDir}` expansion

--- a/packages/tsconfck/src/parse.js
+++ b/packages/tsconfck/src/parse.js
@@ -135,7 +135,11 @@ async function parseFile(tsconfigFile, cache, skipCache) {
  */
 function normalizeTSConfig(tsconfig, dir) {
 	// set baseUrl to absolute path
-	if (tsconfig.compilerOptions?.baseUrl && !path.isAbsolute(tsconfig.compilerOptions.baseUrl)) {
+	if (
+		tsconfig.compilerOptions?.baseUrl &&
+		!tsconfig.compilerOptions.baseUrl.startsWith('${configDir}') &&
+		!path.isAbsolute(tsconfig.compilerOptions.baseUrl)
+	) {
 		tsconfig.compilerOptions.baseUrl = resolve2posix(dir, tsconfig.compilerOptions.baseUrl);
 	}
 

--- a/packages/tsconfck/src/parse.js
+++ b/packages/tsconfck/src/parse.js
@@ -53,6 +53,7 @@ export async function parse(filename, options) {
 			result = await parseFile(tsconfigFile, cache, filename === tsconfigFile);
 			await Promise.all([parseExtends(result, cache), parseReferences(result, options)]);
 		}
+		result.tsconfig = replaceTokens(result.tsconfig, path.dirname(tsconfigFile));
 		resolve(resolveSolutionTSConfig(filename, result));
 	} catch (e) {
 		reject(e);
@@ -138,7 +139,7 @@ function normalizeTSConfig(tsconfig, dir) {
 		tsconfig.compilerOptions.baseUrl = resolve2posix(dir, tsconfig.compilerOptions.baseUrl);
 	}
 
-	return replaceTokens(tsconfig, dir);
+	return tsconfig;
 }
 
 /**

--- a/packages/tsconfck/src/parse.js
+++ b/packages/tsconfck/src/parse.js
@@ -135,14 +135,10 @@ async function parseFile(tsconfigFile, cache, skipCache) {
  */
 function normalizeTSConfig(tsconfig, dir) {
 	// set baseUrl to absolute path
-	if (
-		tsconfig.compilerOptions?.baseUrl &&
-		!tsconfig.compilerOptions.baseUrl.startsWith('${configDir}') &&
-		!path.isAbsolute(tsconfig.compilerOptions.baseUrl)
-	) {
-		tsconfig.compilerOptions.baseUrl = resolve2posix(dir, tsconfig.compilerOptions.baseUrl);
+	const baseUrl = tsconfig.compilerOptions?.baseUrl;
+	if (baseUrl && !baseUrl.startsWith('${') && !path.isAbsolute(baseUrl)) {
+		tsconfig.compilerOptions.baseUrl = resolve2posix(dir, baseUrl);
 	}
-
 	return tsconfig;
 }
 

--- a/packages/tsconfck/tests/fixtures/parse/valid/configDir/tsconfig.base.json
+++ b/packages/tsconfck/tests/fixtures/parse/valid/configDir/tsconfig.base.json
@@ -5,6 +5,7 @@
     "paths": {
       "$src": ["${configDir}/src/**/*"]
     },
+    "baseUrl": "${configDir}/src",
     "outDir": "${configDir}/build"
   }
 }

--- a/packages/tsconfck/tests/parse-native.js
+++ b/packages/tsconfck/tests/parse-native.js
@@ -12,8 +12,7 @@ import { transform as esbuildTransform } from 'esbuild';
 import ts from 'typescript';
 import { TSConfckCache } from '../src/cache.js';
 
-const ts_ver = ts.version.split('.');
-const IS_TS_5_5 = +ts_ver[0] >= 5 && +ts_ver[1] >= 5;
+import { FEAT_$CONFIGDIR } from './util/features.js';
 
 describe('parse', () => {
 	it('should be a function', () => {
@@ -54,7 +53,7 @@ describe('parse', () => {
 	it('should resolve with expected valid tsconfig.json', async () => {
 		const samples = await globFixtures('parse/valid/**/tsconfig.json');
 		for (const filename of samples) {
-			if (!IS_TS_5_5 && filename.includes('configDir')) {
+			if (!FEAT_$CONFIGDIR && filename.includes('configDir')) {
 				continue; // configDir doesn't work in 5.4
 			}
 			const actual = await parseNative(filename);

--- a/packages/tsconfck/tests/parse-native.js
+++ b/packages/tsconfck/tests/parse-native.js
@@ -12,8 +12,8 @@ import { transform as esbuildTransform } from 'esbuild';
 import ts from 'typescript';
 import { TSConfckCache } from '../src/cache.js';
 
-const ts_ver = ts.version.slice(3).split('.');
-const IS_TS_5_5 = ts_ver[0] >= 5 && ts_ver[1] >= 5;
+const ts_ver = ts.version.split('.');
+const IS_TS_5_5 = +ts_ver[0] >= 5 && +ts_ver[1] >= 5;
 
 describe('parse', () => {
 	it('should be a function', () => {

--- a/packages/tsconfck/tests/parse.js
+++ b/packages/tsconfck/tests/parse.js
@@ -11,6 +11,7 @@ import { promises as fs } from 'node:fs';
 import { transform as esbuildTransform } from 'esbuild';
 import ts from 'typescript';
 import { TSConfckCache } from '../src/cache.js';
+import { native2posix } from '../src/util.js';
 
 describe('parse', () => {
 	it('should be a function', () => {
@@ -53,6 +54,17 @@ describe('parse', () => {
 			const actual = await parse(filename);
 			expect(actual.tsconfigFile).toBe(filename);
 			await expectToMatchSnap(actual.tsconfig, `input: ${filename}`, filename, 'parse');
+		}
+	});
+
+	it('should replace configDir', async () => {
+		const samples = await globFixtures('parse/valid/configDir/**/tsconfig.json');
+		for (const filename of samples) {
+			const actual = await parse(filename);
+			expect(actual.tsconfigFile).toBe(filename);
+			expect(actual.tsconfig.compilerOptions.outDir).toBe(
+				native2posix(path.dirname(filename) + '/build')
+			);
 		}
 	});
 

--- a/packages/tsconfck/tests/snapshots/parse/valid/configDir/a/tsconfig.json.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/configDir/a/tsconfig.json.parse-native.json
@@ -14,6 +14,7 @@
 				"<fixture-dir>/parse/valid/configDir/a/src/**/*"
 			]
 		},
+		"baseUrl": "<fixture-dir>/parse/valid/configDir/a/src",
 		"outDir": "<fixture-dir>/parse/valid/configDir/a/build"
 	}
 }

--- a/packages/tsconfck/tests/snapshots/parse/valid/configDir/a/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/configDir/a/tsconfig.json.parse.json
@@ -14,6 +14,7 @@
 				"<fixture-dir>/parse/valid/configDir/a/src/**/*"
 			]
 		},
+		"baseUrl": "<fixture-dir>/parse/valid/configDir/a/src",
 		"outDir": "<fixture-dir>/parse/valid/configDir/a/build"
 	}
 }

--- a/packages/tsconfck/tests/snapshots/parse/valid/configDir/a/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/configDir/a/tsconfig.json.parse.json
@@ -3,17 +3,17 @@
 		"../tsconfig.base.json"
 	],
 	"include": [
-		"<fixture-dir>/parse/valid/configDir/**/*"
+		"<fixture-dir>/parse/valid/configDir/a/**/*"
 	],
 	"exclude": [
-		"<fixture-dir>/parse/valid/configDir/src/**/*.spec.ts"
+		"<fixture-dir>/parse/valid/configDir/a/src/**/*.spec.ts"
 	],
 	"compilerOptions": {
 		"paths": {
 			"$src": [
-				"<fixture-dir>/parse/valid/configDir/src/**/*"
+				"<fixture-dir>/parse/valid/configDir/a/src/**/*"
 			]
 		},
-		"outDir": "<fixture-dir>/parse/valid/configDir/build"
+		"outDir": "<fixture-dir>/parse/valid/configDir/a/build"
 	}
 }

--- a/packages/tsconfck/tests/snapshots/parse/valid/configDir/b/tsconfig.json.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/configDir/b/tsconfig.json.parse-native.json
@@ -14,6 +14,7 @@
 				"<fixture-dir>/parse/valid/configDir/b/src/**/*"
 			]
 		},
+		"baseUrl": "<fixture-dir>/parse/valid/configDir/b/src",
 		"outDir": "<fixture-dir>/parse/valid/configDir/b/build"
 	}
 }

--- a/packages/tsconfck/tests/snapshots/parse/valid/configDir/b/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/configDir/b/tsconfig.json.parse.json
@@ -14,6 +14,7 @@
 				"<fixture-dir>/parse/valid/configDir/b/src/**/*"
 			]
 		},
+		"baseUrl": "<fixture-dir>/parse/valid/configDir/b/src",
 		"outDir": "<fixture-dir>/parse/valid/configDir/b/build"
 	}
 }

--- a/packages/tsconfck/tests/snapshots/parse/valid/configDir/b/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/configDir/b/tsconfig.json.parse.json
@@ -3,17 +3,17 @@
 		"../tsconfig.base.json"
 	],
 	"include": [
-		"<fixture-dir>/parse/valid/configDir/**/*"
+		"<fixture-dir>/parse/valid/configDir/b/**/*"
 	],
 	"exclude": [
-		"<fixture-dir>/parse/valid/configDir/src/**/*.spec.ts"
+		"<fixture-dir>/parse/valid/configDir/b/src/**/*.spec.ts"
 	],
 	"compilerOptions": {
 		"paths": {
 			"$src": [
-				"<fixture-dir>/parse/valid/configDir/src/**/*"
+				"<fixture-dir>/parse/valid/configDir/b/src/**/*"
 			]
 		},
-		"outDir": "<fixture-dir>/parse/valid/configDir/build"
+		"outDir": "<fixture-dir>/parse/valid/configDir/b/build"
 	}
 }

--- a/packages/tsconfck/tests/util/expect.js
+++ b/packages/tsconfck/tests/util/expect.js
@@ -2,7 +2,7 @@ import { expect } from 'vitest';
 import { fixtures, snapName } from './fixture-paths.js';
 
 const fixtureDirRegex = new RegExp(
-	fixtures.replace(/[.*+?^${}()|[\]]/g, '\\$&').replace(/[/\\]/g, '[/\\\\]'),
+	fixtures.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/(\/|\\\\)/g, '[/\\\\]'),
 	'g'
 );
 function normalizeSnapshot(str) {

--- a/packages/tsconfck/tests/util/features.js
+++ b/packages/tsconfck/tests/util/features.js
@@ -1,0 +1,4 @@
+import ts from 'typescript';
+
+const [major, minor] = ts.version.split('.', 3).map((n) => Number(n));
+export const FEAT_$CONFIGDIR = major > 5 || (major === 5 && minor >= 5);

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -38,5 +38,5 @@
 		null,
 		null
 	],
-	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCYJC,OAAOA;;;;;;;iBCTbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCXnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC2BJC,KAAKA;cAiWdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCjWTC,WAAWA;cAkOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;WC5PpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAkCnBC,oBAAoBA;;;;WAIpBC,sBAAsBA;;;;;;;;;;;;;;;WAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
+	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCYJC,OAAOA;;;;;;;iBCTbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCXnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC2BJC,KAAKA;cA6VdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC7VTC,WAAWA;cAkOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;WC5PpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAkCnBC,oBAAoBA;;;;WAIpBC,sBAAsBA;;;;;;;;;;;;;;;WAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
 }

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -38,5 +38,5 @@
 		null,
 		null
 	],
-	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCYJC,OAAOA;;;;;;;iBCTbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCXnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC2BJC,KAAKA;cA4VdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC5VTC,WAAWA;cAkOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;WC5PpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAkCnBC,oBAAoBA;;;;WAIpBC,sBAAsBA;;;;;;;;;;;;;;;WAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
+	"mappings": ";;;;;;;;iBAUsBA,IAAIA;;;;;;;;iBCYJC,OAAOA;;;;;;;iBCTbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;cCXnBC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC2BJC,KAAKA;cAiWdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCjWTC,WAAWA;cAkOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;WC5PpBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WAkCnBC,oBAAoBA;;;;WAIpBC,sBAAsBA;;;;;;;;;;;;;;;WAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;WA6BnBC,0BAA0BA;;;;;;;;;;;;WAY1BC,yBAAyBA"
 }


### PR DESCRIPTION
This builds on #178 and fixes differences between parse and parseNative for configDir for typescript 5.5