### PR TITLE
fix: improve  replacement to work with extending from node_modules

### DIFF
--- a/.changeset/purple-parents-begin.md
+++ b/.changeset/purple-parents-begin.md
@@ -1,0 +1,5 @@
+---
+'tsconfck': patch
+---
+
+correctly replace ${configDir} in tsconfig files loaded from packages in node_modules

--- a/packages/tsconfck/package.json
+++ b/packages/tsconfck/package.json
@@ -49,8 +49,10 @@
 	},
 	"devDependencies": {
 		"@tsconfig/node18": "^18.2.4",
+		"@tsconfig/strictest": "^2.0.5",
 		"@vitest/coverage-v8": "^2.0.5",
 		"esbuild": "^0.23.1",
+		"isaacscript-tsconfig": "^6.0.0",
 		"tiny-glob": "^0.2.9",
 		"typescript": "^5.5.4",
 		"vitest": "^2.0.5"

--- a/packages/tsconfck/src/parse.js
+++ b/packages/tsconfck/src/parse.js
@@ -367,7 +367,7 @@ function rebaseRelative(key, value, prependPath) {
  * @returns {string}
  */
 function rebasePath(value, prependPath) {
-	if (path.isAbsolute(value)) {
+	if (path.isAbsolute(value) || value.startsWith('${configDir}')) {
 		return value;
 	} else {
 		// relative paths use posix syntax in tsconfig

--- a/packages/tsconfck/src/util.js
+++ b/packages/tsconfck/src/util.js
@@ -304,7 +304,7 @@ function pattern2regex(resolvedPattern, allowJs) {
 export function replaceTokens(tsconfig, configDir) {
 	return JSON.parse(
 		JSON.stringify(tsconfig)
-			// replace ${configDir}, accounting for rebaseRelative emitted ../${configDir}
-			.replaceAll(/"(?:\.\.\/)*\${configDir}/g, `"${native2posix(configDir)}`)
+			// replace ${configDir}
+			.replaceAll(/"\${configDir}/g, `"${native2posix(configDir)}`)
 	);
 }

--- a/packages/tsconfck/tests/fixtures/parse/valid/configDirNpm/tsconfig.json
+++ b/packages/tsconfck/tests/fixtures/parse/valid/configDirNpm/tsconfig.json
@@ -1,0 +1,9 @@
+// The configuration file for TypeScript.
+{
+  "$schema": "https://raw.githubusercontent.com/complete-ts/complete/main/packages/complete-tsconfig/schemas/tsconfig-strict-schema.json",
+
+  "extends": [
+    // https://github.com/IsaacScript/isaacscript/blob/main/packages/isaacscript-tsconfig/tsconfig.base.json
+    "isaacscript-tsconfig/tsconfig.base.json",
+  ],
+}

--- a/packages/tsconfck/tests/snapshots/parse/valid/configDirNpm/tsconfig.json.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/configDirNpm/tsconfig.json.parse-native.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://raw.githubusercontent.com/complete-ts/complete/main/packages/complete-tsconfig/schemas/tsconfig-strict-schema.json",
+	"extends": [
+		"isaacscript-tsconfig/tsconfig.base.json"
+	],
+	"include": [
+		"<fixture-dir>/parse/valid/configDirNpm/src/**/*.ts",
+		"<fixture-dir>/parse/valid/configDirNpm/src/**/*.tsx"
+	],
+	"compilerOptions": {
+		"strict": true,
+		"allowUnusedLabels": false,
+		"allowUnreachableCode": false,
+		"exactOptionalPropertyTypes": false,
+		"noFallthroughCasesInSwitch": false,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"isolatedModules": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"outDir": "<fixture-dir>/parse/valid/configDirNpm/dist"
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/valid/configDirNpm/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/configDirNpm/tsconfig.json.parse.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://raw.githubusercontent.com/complete-ts/complete/main/packages/complete-tsconfig/schemas/tsconfig-strict-schema.json",
+	"extends": [
+		"isaacscript-tsconfig/tsconfig.base.json"
+	],
+	"compilerOptions": {
+		"exactOptionalPropertyTypes": false,
+		"noFallthroughCasesInSwitch": false,
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"outDir": "<fixture-dir>/parse/valid/configDirNpm/dist",
+		"strict": true,
+		"allowUnusedLabels": false,
+		"allowUnreachableCode": false,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noUncheckedIndexedAccess": true,
+		"isolatedModules": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true
+	},
+	"include": [
+		"<fixture-dir>/parse/valid/configDirNpm/src/**/*.ts",
+		"<fixture-dir>/parse/valid/configDirNpm/src/**/*.tsx"
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/valid/configDirNpm/tsconfig.json.to-json.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/configDirNpm/tsconfig.json.to-json.json
@@ -1,0 +1,9 @@
+                                         
+{
+  "$schema": "https://raw.githubusercontent.com/complete-ts/complete/main/packages/complete-tsconfig/schemas/tsconfig-strict-schema.json",
+
+  "extends": [
+                                                                                                            
+    "isaacscript-tsconfig/tsconfig.base.json" 
+  ] 
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,12 +77,18 @@ importers:
       '@tsconfig/node18':
         specifier: ^18.2.4
         version: 18.2.4
+      '@tsconfig/strictest':
+        specifier: ^2.0.5
+        version: 2.0.5
       '@vitest/coverage-v8':
         specifier: ^2.0.5
         version: 2.0.5(vitest@2.0.5)
       esbuild:
         specifier: ^0.23.1
         version: 0.23.1
+      isaacscript-tsconfig:
+        specifier: ^6.0.0
+        version: 6.0.0
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9
@@ -625,8 +631,14 @@ packages:
     resolution: {integrity: sha512-qhUGGDHcpbY2zpjW3SwqchuW8J/5EzlPFud7xNntHKA7f3a/mx5+g+ruJKFHSAiVZYo30PALt+AyhmPUNKH/Og==}
     engines: {node: ^14.13.1 || ^16.0.0 || >=18}
 
+  '@tsconfig/node-lts@20.1.3':
+    resolution: {integrity: sha512-m3b7EP2U+h5tNSpaBMfcTuHmHn04wrgRPQQrfKt75YIPq6kPs2153/KfPHdqkEWGx5pEBvS6rnvToT+yTtC1iw==}
+
   '@tsconfig/node18@18.2.4':
     resolution: {integrity: sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==}
+
+  '@tsconfig/strictest@2.0.5':
+    resolution: {integrity: sha512-ec4tjL2Rr0pkZ5hww65c+EEPYwxOi4Ryv+0MtjeaSQRJyq322Q27eOQiFbuNgw2hpL4hB1/W/HBGk3VKS43osg==}
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
@@ -1234,6 +1246,9 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  isaacscript-tsconfig@6.0.0:
+    resolution: {integrity: sha512-FM9+2qGT7qgDWuAukFSrd5Xx2rlbybTLakjwSY30rUbLqXvfa8NKhSD7WJnFSXLaQtc7xgFbLNoIa6LpDK6kAw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2447,7 +2462,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@tsconfig/node-lts@20.1.3': {}
+
   '@tsconfig/node18@18.2.4': {}
+
+  '@tsconfig/strictest@2.0.5': {}
 
   '@types/estree@1.0.5': {}
 
@@ -3097,6 +3116,11 @@ snapshots:
       better-path-resolve: 1.0.0
 
   is-windows@1.0.2: {}
+
+  isaacscript-tsconfig@6.0.0:
+    dependencies:
+      '@tsconfig/node-lts': 20.1.3
+      '@tsconfig/strictest': 2.0.5
 
   isexe@2.0.0: {}
 


### PR DESCRIPTION
fixes #188 

The issue was rebaseRelative prepending segments in front of `${configDir}` and the replacer at the end did not work with that. 

Fixed by skipping rebaseRelative if value starts with `${configDir}`