### PR TITLE
fix(globMatch): support implicit globs

### DIFF
--- a/.changeset/neat-carpets-roll.md
+++ b/.changeset/neat-carpets-roll.md
@@ -1,0 +1,5 @@
+---
+'tsconfck': patch
+---
+
+fix(glob-matching): add implicit **/\* to path patterns that do not have an extension or wildcard in their last segment, eg `src` becomes `src/**/\*` for matching.

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-implicit-globs/src/foo.ts
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-implicit-globs/src/foo.ts
@@ -1,0 +1,3 @@
+export function foo() {
+	return 'foo';
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-implicit-globs/tests/foo.test.ts
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-implicit-globs/tests/foo.test.ts
@@ -1,0 +1,9 @@
+import { foo } from '../src/foo';
+import * as assert from 'assert';
+
+function test() {
+	const actual = foo();
+	const expected = 'foo';
+	assert.strictEqual(actual, expected);
+}
+test();

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-implicit-globs/tsconfig.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-implicit-globs/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./tsconfig.src.json"},
+    {"path": "./tsconfig.test.json"}
+  ]
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-implicit-globs/tsconfig.src.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-implicit-globs/tsconfig.src.json
@@ -1,0 +1,7 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "composite": true,
+    "strict": true
+  }
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-implicit-globs/tsconfig.test.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-implicit-globs/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "include": ["tests"],
+  "compilerOptions": {
+    "composite": true,
+    "strict": false
+  }
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/src/foo.ts.tsconfig.parse-native.ignore-files.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/src/foo.ts.tsconfig.parse-native.ignore-files.json
@@ -1,0 +1,12 @@
+{
+	"files": [],
+	"references": [
+		{
+			"path": "./tsconfig.src.json"
+		},
+		{
+			"path": "./tsconfig.test.json"
+		}
+	],
+	"include": []
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/src/foo.ts.tsconfig.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/src/foo.ts.tsconfig.parse-native.json
@@ -1,0 +1,9 @@
+{
+	"include": [
+		"src"
+	],
+	"compilerOptions": {
+		"composite": true,
+		"strict": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/src/foo.ts.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/src/foo.ts.tsconfig.parse.json
@@ -1,0 +1,9 @@
+{
+	"include": [
+		"src"
+	],
+	"compilerOptions": {
+		"composite": true,
+		"strict": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tests/foo.test.ts.tsconfig.parse-native.ignore-files.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tests/foo.test.ts.tsconfig.parse-native.ignore-files.json
@@ -1,0 +1,12 @@
+{
+	"files": [],
+	"references": [
+		{
+			"path": "./tsconfig.src.json"
+		},
+		{
+			"path": "./tsconfig.test.json"
+		}
+	],
+	"include": []
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tests/foo.test.ts.tsconfig.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tests/foo.test.ts.tsconfig.parse-native.json
@@ -1,0 +1,9 @@
+{
+	"include": [
+		"tests"
+	],
+	"compilerOptions": {
+		"composite": true,
+		"strict": false
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tests/foo.test.ts.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tests/foo.test.ts.tsconfig.parse.json
@@ -1,0 +1,9 @@
+{
+	"include": [
+		"tests"
+	],
+	"compilerOptions": {
+		"composite": true,
+		"strict": false
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tsconfig.json.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tsconfig.json.parse-native.json
@@ -1,0 +1,11 @@
+{
+	"files": [],
+	"references": [
+		{
+			"path": "./tsconfig.src.json"
+		},
+		{
+			"path": "./tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tsconfig.json.parse.json
@@ -1,0 +1,11 @@
+{
+	"files": [],
+	"references": [
+		{
+			"path": "./tsconfig.src.json"
+		},
+		{
+			"path": "./tsconfig.test.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tsconfig.src.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tsconfig.src.json.tsconfig.parse.json
@@ -1,0 +1,9 @@
+{
+	"include": [
+		"src"
+	],
+	"compilerOptions": {
+		"composite": true,
+		"strict": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tsconfig.test.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-implicit-globs/tsconfig.test.json.tsconfig.parse.json
@@ -1,0 +1,9 @@
+{
+	"include": [
+		"tests"
+	],
+	"compilerOptions": {
+		"composite": true,
+		"strict": false
+	}
+}


### PR DESCRIPTION
fixes #199 

Also includes a minor perf improvement to not use regex for patterns that only have a single glob-all in them, in that case it is sufficient to ensure equality of static prefix and suffix. This helps with this fix a the implicitly added glob is one of these cases.