### PR TITLE
feat: rebase extended `paths` when `baseUrl` is undefined

### DIFF
--- a/packages/tsconfck/src/parse.js
+++ b/packages/tsconfck/src/parse.js
@@ -299,10 +299,6 @@ function extendTSConfig(extending, extended) {
 				if (Object.prototype.hasOwnProperty.call(extendingConfig.compilerOptions, option)) {
 					continue; // already set
 				}
-				if (option === 'paths') {
-					extendingConfig.compilerOptions.paths = extendedConfig.compilerOptions.paths;
-					continue; // rebased below
-				}
 				extendingConfig.compilerOptions[option] = rebaseRelative(
 					option,
 					extendedConfig.compilerOptions[option],
@@ -315,11 +311,12 @@ function extendTSConfig(extending, extended) {
 				extendingConfig.compilerOptions.paths === extendedConfig.compilerOptions.paths
 			) {
 				for (const pattern of Object.keys(extendingConfig.compilerOptions.paths)) {
-					extendingConfig.compilerOptions.paths[pattern] = rebaseRelative(
-						'paths',
-						extendedConfig.compilerOptions.paths[pattern],
-						relativePath
-					);
+					const paths = extendingConfig.compilerOptions.paths[pattern];
+					if (Array.isArray(paths)) {
+						extendingConfig.compilerOptions.paths[pattern] = paths.map((x) =>
+							rebasePath(x, relativePath)
+						);
+					}
 				}
 			}
 		} else if (extendingConfig[key] === undefined) {
@@ -346,7 +343,6 @@ const REBASE_KEYS = [
 	'exclude',
 	// compilerOptions
 	'baseUrl',
-	'paths',
 	'rootDir',
 	'rootDirs',
 	'typeRoots',

--- a/packages/tsconfck/src/parse.js
+++ b/packages/tsconfck/src/parse.js
@@ -310,6 +310,9 @@ function extendTSConfig(extending, extended) {
 				extendingConfig.compilerOptions.paths !== undefined &&
 				extendingConfig.compilerOptions.paths === extendedConfig.compilerOptions.paths
 			) {
+				// copy paths to avoid mutating the original.
+				extendingConfig.compilerOptions.paths = { ...extendingConfig.compilerOptions.paths };
+
 				for (const pattern of Object.keys(extendingConfig.compilerOptions.paths)) {
 					const paths = extendingConfig.compilerOptions.paths[pattern];
 					if (Array.isArray(paths)) {

--- a/packages/tsconfck/src/parse.js
+++ b/packages/tsconfck/src/parse.js
@@ -299,11 +299,28 @@ function extendTSConfig(extending, extended) {
 				if (Object.prototype.hasOwnProperty.call(extendingConfig.compilerOptions, option)) {
 					continue; // already set
 				}
+				if (option === 'paths') {
+					extendingConfig.compilerOptions.paths = extendedConfig.compilerOptions.paths;
+					continue; // rebased below
+				}
 				extendingConfig.compilerOptions[option] = rebaseRelative(
 					option,
 					extendedConfig.compilerOptions[option],
 					relativePath
 				);
+			}
+			if (
+				extendingConfig.compilerOptions.baseUrl === undefined &&
+				extendingConfig.compilerOptions.paths !== undefined &&
+				extendingConfig.compilerOptions.paths === extendedConfig.compilerOptions.paths
+			) {
+				for (const pattern of Object.keys(extendingConfig.compilerOptions.paths)) {
+					extendingConfig.compilerOptions.paths[pattern] = rebaseRelative(
+						'paths',
+						extendedConfig.compilerOptions.paths[pattern],
+						relativePath
+					);
+				}
 			}
 		} else if (extendingConfig[key] === undefined) {
 			if (key === 'watchOptions') {
@@ -329,6 +346,7 @@ const REBASE_KEYS = [
 	'exclude',
 	// compilerOptions
 	'baseUrl',
+	'paths',
 	'rootDir',
 	'rootDirs',
 	'typeRoots',

--- a/packages/tsconfck/tests/fixtures/parse/valid/with_extends/paths_without_baseurl/lib/foo.ts
+++ b/packages/tsconfck/tests/fixtures/parse/valid/with_extends/paths_without_baseurl/lib/foo.ts
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/packages/tsconfck/tests/fixtures/parse/valid/with_extends/paths_without_baseurl/src/import-foo.ts
+++ b/packages/tsconfck/tests/fixtures/parse/valid/with_extends/paths_without_baseurl/src/import-foo.ts
@@ -1,0 +1,2 @@
+import foo from '$lib/foo';
+export const foobar = foo + 'bar;';

--- a/packages/tsconfck/tests/fixtures/parse/valid/with_extends/paths_without_baseurl/src/tsconfig.json
+++ b/packages/tsconfck/tests/fixtures/parse/valid/with_extends/paths_without_baseurl/src/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base",
+  "compilerOptions": {
+    "types": ["foo"],
+    "strictNullChecks": true
+  }
+}

--- a/packages/tsconfck/tests/fixtures/parse/valid/with_extends/paths_without_baseurl/tsconfig.base.json
+++ b/packages/tsconfck/tests/fixtures/parse/valid/with_extends/paths_without_baseurl/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.parent.json",
+  "compilerOptions": {
+    "paths": {
+      "$lib": ["*","./lib"],
+      "$src": ["./src"]
+    }
+  },
+  "include": ["src/**/*","lib/**/*"]
+}

--- a/packages/tsconfck/tests/snapshots/parse/valid/with_extends/paths_without_baseurl/src/tsconfig.json.parse-native.ignore-files.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/with_extends/paths_without_baseurl/src/tsconfig.json.parse-native.ignore-files.json
@@ -1,0 +1,29 @@
+{
+	"extends": "../tsconfig.base",
+	"compilerOptions": {
+		"types": [
+			"foo"
+		],
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"paths": {
+			"$lib": [
+				"*",
+				"./lib"
+			],
+			"$src": [
+				"./src"
+			]
+		}
+	},
+	"files": [],
+	"include": [],
+	"exclude": [
+		"../../**/foo/*"
+	],
+	"watchOptions": {
+		"watchFile": "useFsEvents",
+		"watchDirectory": "useFsEvents",
+		"fallbackPolling": "dynamicPriority"
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/valid/with_extends/paths_without_baseurl/src/tsconfig.json.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/with_extends/paths_without_baseurl/src/tsconfig.json.parse-native.json
@@ -1,0 +1,31 @@
+{
+	"extends": "../tsconfig.base",
+	"compilerOptions": {
+		"types": [
+			"foo"
+		],
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"paths": {
+			"$lib": [
+				"*",
+				"./lib"
+			],
+			"$src": [
+				"./src"
+			]
+		}
+	},
+	"include": [
+		"../src/**/*",
+		"../lib/**/*"
+	],
+	"exclude": [
+		"../../**/foo/*"
+	],
+	"watchOptions": {
+		"watchFile": "useFsEvents",
+		"watchDirectory": "useFsEvents",
+		"fallbackPolling": "dynamicPriority"
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/valid/with_extends/paths_without_baseurl/src/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/with_extends/paths_without_baseurl/src/tsconfig.json.parse.json
@@ -1,0 +1,31 @@
+{
+	"extends": "../tsconfig.base",
+	"compilerOptions": {
+		"types": [
+			"foo"
+		],
+		"strictNullChecks": true,
+		"paths": {
+			"$lib": [
+				"../*",
+				"../lib"
+			],
+			"$src": [
+				"../src"
+			]
+		},
+		"noImplicitAny": true
+	},
+	"include": [
+		"../src/**/*",
+		"../lib/**/*"
+	],
+	"watchOptions": {
+		"watchFile": "useFsEvents",
+		"watchDirectory": "useFsEvents",
+		"fallbackPolling": "dynamicPriority"
+	},
+	"exclude": [
+		"../../**/foo/*"
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/valid/with_extends/paths_without_baseurl/src/tsconfig.json.to-json.json
+++ b/packages/tsconfck/tests/snapshots/parse/valid/with_extends/paths_without_baseurl/src/tsconfig.json.to-json.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base",
+  "compilerOptions": {
+    "types": ["foo"],
+    "strictNullChecks": true
+  }
+}


### PR DESCRIPTION
It's possible to set `paths` without an accompanying `baseUrl`. In lieu of a `baseUrl`, TypeScript uses the directory of the tsconfig file for path resolution.

It's beneficial to not have a `baseUrl` defined, because `baseUrl` has a (commonly undesired) side effect on path resolution, where bare specifiers are resolved with it.

For example, consider the following case:
- I import `foo`
- I have `baseUrl` set to `./`
- No package named `foo` exists in any `node_modules` folder

If I happen to have a `./foo` folder, TypeScript will use it to resolve my `foo` import. Without `baseUrl` defined, this wouldn't happen, but tsconfig `paths` would still be used by TypeScript.

### The Solution

This PR only has an effect when `baseUrl` is **not** defined in both the extending and extended configs.

It's assumed that, when `baseUrl` is defined, the consumer will use it to resolve the `paths` on an as-needed basis. Since the `baseUrl` is rebased, this all works as expected.

But when `baseUrl` is undefined, the `paths` need to be rebased in order to preserve the original intention. When the `paths` are defined in the *extended* config (without a `baseUrl`), they are intended to be relative to that config's directory. Without my PR, `tsconfck` doesn't respect this intention.

I've added a test to ensure all is working as expected.

### Related

https://github.com/aleclarson/vite-tsconfig-paths/issues/150
https://github.com/aleclarson/vite-tsconfig-paths/issues/164
https://github.com/aleclarson/vite-tsconfig-paths/issues/167