### PR TITLE
fix: resolve configDir token in referenced files

### DIFF
--- a/.changeset/spotty-maps-mix.md
+++ b/.changeset/spotty-maps-mix.md
@@ -1,0 +1,5 @@
+---
+'tsconfck': patch
+---
+
+resolve ${configDir} in referenced tsconfig files

--- a/packages/tsconfck/src/parse-native.js
+++ b/packages/tsconfck/src/parse-native.js
@@ -249,7 +249,9 @@ function result2tsconfig(result, ts, tsconfigFile) {
 		delete tsconfig.compileOnSave;
 	}
 	// ts itself has not replaced all tokens at this point, make sure they are
-	return replaceTokens(tsconfig, path.dirname(tsconfigFile));
+	const parseResult = { tsconfig, tsconfigFile };
+	replaceTokens(parseResult);
+	return parseResult.tsconfig;
 }
 
 export class TSConfckParseNativeError extends Error {

--- a/packages/tsconfck/src/parse.js
+++ b/packages/tsconfck/src/parse.js
@@ -53,9 +53,7 @@ export async function parse(filename, options) {
 			result = await parseFile(tsconfigFile, cache, filename === tsconfigFile);
 			await Promise.all([parseExtends(result, cache), parseReferences(result, options)]);
 		}
-		const dir = path.dirname(tsconfigFile);
-		result.tsconfig = replaceTokens(result.tsconfig, dir);
-		result.referenced?.forEach((ref) => (ref.tsconfig = replaceTokens(ref.tsconfig, dir)));
+		replaceTokens(result);
 		resolve(resolveSolutionTSConfig(filename, result));
 	} catch (e) {
 		reject(e);
@@ -161,6 +159,7 @@ async function parseReferences(result, options) {
 	await Promise.all(referenced.map((ref) => parseExtends(ref, options?.cache)));
 	referenced.forEach((ref) => {
 		ref.solution = result;
+		replaceTokens(ref);
 	});
 	result.referenced = referenced;
 }

--- a/packages/tsconfck/src/parse.js
+++ b/packages/tsconfck/src/parse.js
@@ -53,7 +53,9 @@ export async function parse(filename, options) {
 			result = await parseFile(tsconfigFile, cache, filename === tsconfigFile);
 			await Promise.all([parseExtends(result, cache), parseReferences(result, options)]);
 		}
-		result.tsconfig = replaceTokens(result.tsconfig, path.dirname(tsconfigFile));
+		const dir = path.dirname(tsconfigFile);
+		result.tsconfig = replaceTokens(result.tsconfig, dir);
+		result.referenced?.forEach((ref) => (ref.tsconfig = replaceTokens(ref.tsconfig, dir)));
 		resolve(resolveSolutionTSConfig(filename, result));
 	} catch (e) {
 		reject(e);

--- a/packages/tsconfck/src/util.js
+++ b/packages/tsconfck/src/util.js
@@ -326,14 +326,14 @@ function pattern2regex(resolvedPattern, allowJs) {
 
 /**
  * replace tokens like ${configDir}
- * @param {any} tsconfig
- * @param {string} configDir
- * @returns {any}
+ * @param {import('./public.d.ts').TSConfckParseResult} result
  */
-export function replaceTokens(tsconfig, configDir) {
-	return JSON.parse(
-		JSON.stringify(tsconfig)
-			// replace ${configDir}
-			.replaceAll(/"\${configDir}/g, `"${native2posix(configDir)}`)
-	);
+export function replaceTokens(result) {
+	if (result.tsconfig) {
+		result.tsconfig = JSON.parse(
+			JSON.stringify(result.tsconfig)
+				// replace ${configDir}
+				.replaceAll(/"\${configDir}/g, `"${native2posix(path.dirname(result.tsconfigFile))}`)
+		);
+	}
 }

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir-and-extends/packages/foo/src/foo.ts
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir-and-extends/packages/foo/src/foo.ts
@@ -1,0 +1,3 @@
+export function foo() {
+	return 'foo';
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir-and-extends/packages/foo/tsconfig.foo.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir-and-extends/packages/foo/tsconfig.foo.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.base.json"
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir-and-extends/tsconfig.base.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir-and-extends/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "noUnusedLocals": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+  },
+  "include": ["${configDir}/src/*"]
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir-and-extends/tsconfig.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir-and-extends/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": [],
+  "references": [{
+    "path": "./packages/foo/tsconfig.foo.json"
+  }]
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir/src/foo.ts
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir/src/foo.ts
@@ -1,0 +1,3 @@
+export function foo() {
+	return 'foo';
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir/tsconfig.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": [],
+  "references": [{
+    "path": "./tsconfig.src.json"
+  }]
+}

--- a/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir/tsconfig.src.json
+++ b/packages/tsconfck/tests/fixtures/parse/solution/referenced-with-configDir/tsconfig.src.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "noUnusedLocals": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+  },
+  "include": ["${configDir}/src/*"]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/packages/foo/src/foo.ts.tsconfig.parse-native.ignore-files.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/packages/foo/src/foo.ts.tsconfig.parse-native.ignore-files.json
@@ -1,0 +1,9 @@
+{
+	"files": [],
+	"references": [
+		{
+			"path": "./packages/foo/tsconfig.foo.json"
+		}
+	],
+	"include": []
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/packages/foo/src/foo.ts.tsconfig.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/packages/foo/src/foo.ts.tsconfig.parse-native.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": [
+		"<fixture-dir>/parse/solution/referenced-with-configDir-and-extends/packages/foo/src/*"
+	],
+	"compilerOptions": {
+		"module": "es2022",
+		"moduleResolution": "bundler",
+		"noUnusedLocals": true,
+		"skipLibCheck": true,
+		"experimentalDecorators": true
+	}
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/packages/foo/src/foo.ts.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/packages/foo/src/foo.ts.tsconfig.parse.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "ES2022",
+		"moduleResolution": "bundler",
+		"noUnusedLocals": true,
+		"skipLibCheck": true,
+		"experimentalDecorators": true
+	},
+	"include": [
+		"<fixture-dir>/parse/solution/referenced-with-configDir-and-extends/packages/foo/src/*"
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/packages/foo/tsconfig.foo.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/packages/foo/tsconfig.foo.json.tsconfig.parse.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "ES2022",
+		"moduleResolution": "bundler",
+		"noUnusedLocals": true,
+		"skipLibCheck": true,
+		"experimentalDecorators": true
+	},
+	"include": [
+		"<fixture-dir>/parse/solution/referenced-with-configDir-and-extends/packages/foo/src/*"
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/tsconfig.base.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/tsconfig.base.json.tsconfig.parse.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"module": "ES2022",
+		"moduleResolution": "bundler",
+		"noUnusedLocals": true,
+		"skipLibCheck": true,
+		"experimentalDecorators": true
+	},
+	"include": [
+		"${configDir}/src/*"
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/tsconfig.json.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/tsconfig.json.parse-native.json
@@ -1,0 +1,8 @@
+{
+	"files": [],
+	"references": [
+		{
+			"path": "./packages/foo/tsconfig.foo.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir-and-extends/tsconfig.json.parse.json
@@ -1,0 +1,8 @@
+{
+	"files": [],
+	"references": [
+		{
+			"path": "./packages/foo/tsconfig.foo.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/src/foo.ts.tsconfig.parse-native.ignore-files.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/src/foo.ts.tsconfig.parse-native.ignore-files.json
@@ -1,0 +1,9 @@
+{
+	"files": [],
+	"references": [
+		{
+			"path": "./tsconfig.src.json"
+		}
+	],
+	"include": []
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/src/foo.ts.tsconfig.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/src/foo.ts.tsconfig.parse-native.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"module": "es2022",
+		"moduleResolution": "bundler",
+		"noUnusedLocals": true,
+		"skipLibCheck": true,
+		"experimentalDecorators": true
+	},
+	"include": [
+		"<fixture-dir>/parse/solution/referenced-with-configDir/src/*"
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/src/foo.ts.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/src/foo.ts.tsconfig.parse.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"module": "ES2022",
+		"moduleResolution": "bundler",
+		"noUnusedLocals": true,
+		"skipLibCheck": true,
+		"experimentalDecorators": true
+	},
+	"include": [
+		"<fixture-dir>/parse/solution/referenced-with-configDir/src/*"
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/tsconfig.json.parse-native.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/tsconfig.json.parse-native.json
@@ -1,0 +1,8 @@
+{
+	"files": [],
+	"references": [
+		{
+			"path": "./tsconfig.src.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/tsconfig.json.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/tsconfig.json.parse.json
@@ -1,0 +1,8 @@
+{
+	"files": [],
+	"references": [
+		{
+			"path": "./tsconfig.src.json"
+		}
+	]
+}

--- a/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/tsconfig.src.json.tsconfig.parse.json
+++ b/packages/tsconfck/tests/snapshots/parse/solution/referenced-with-configDir/tsconfig.src.json.tsconfig.parse.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"module": "ES2022",
+		"moduleResolution": "bundler",
+		"noUnusedLocals": true,
+		"skipLibCheck": true,
+		"experimentalDecorators": true
+	},
+	"include": [
+		"<fixture-dir>/parse/solution/referenced-with-configDir/src/*"
+	]
+}

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -41,6 +41,6 @@
 		null,
 		null
 	],
-	"mappings": ";kBAEiBA,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAkCnBC,oBAAoBA;;;;kBAIpBC,sBAAsBA;;;;;;;;;;;;;;;kBAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBA6BnBC,0BAA0BA;;;;;;;;;;;;kBAY1BC,yBAAyBA;;;;;;;;;;;;;;;;;;;;;;;;;;cC/F7BC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCSJC,IAAIA;;;;;;;;iBCYJC,OAAOA;;;;;;;iBCTbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;;;;;;;iBCgBVC,KAAKA;cA+VdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC/VTC,WAAWA;cAkOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;MC9MzBC,iBAAiBA",
+	"mappings": ";kBAEiBA,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAkCnBC,oBAAoBA;;;;kBAIpBC,sBAAsBA;;;;;;;;;;;;;;;kBAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBA6BnBC,0BAA0BA;;;;;;;;;;;;kBAY1BC,yBAAyBA;;;;;;;;;;;;;;;;;;;;;;;;;;cC/F7BC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCSJC,IAAIA;;;;;;;;iBCYJC,OAAOA;;;;;;;iBCTbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;;;;;;;iBCgBVC,KAAKA;cA8VdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC9VTC,WAAWA;cAoOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;MChNzBC,iBAAiBA",
 	"ignoreList": []
 }

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -41,6 +41,6 @@
 		null,
 		null
 	],
-	"mappings": ";kBAEiBA,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAkCnBC,oBAAoBA;;;;kBAIpBC,sBAAsBA;;;;;;;;;;;;;;;kBAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBA6BnBC,0BAA0BA;;;;;;;;;;;;kBAY1BC,yBAAyBA;;;;;;;;;;;;;;;;;;;;;;;;;;cC/F7BC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCSJC,IAAIA;;;;;;;;iBCYJC,OAAOA;;;;;;;iBCTbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;;;;;;;iBCgBVC,KAAKA;cA6VdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC7VTC,WAAWA;cAkOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;MC9MzBC,iBAAiBA",
+	"mappings": ";kBAEiBA,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAkCnBC,oBAAoBA;;;;kBAIpBC,sBAAsBA;;;;;;;;;;;;;;;kBAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBA6BnBC,0BAA0BA;;;;;;;;;;;;kBAY1BC,yBAAyBA;;;;;;;;;;;;;;;;;;;;;;;;;;cC/F7BC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCSJC,IAAIA;;;;;;;;iBCYJC,OAAOA;;;;;;;iBCTbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;;;;;;;iBCgBVC,KAAKA;cA+VdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC/VTC,WAAWA;cAkOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;MC9MzBC,iBAAiBA",
 	"ignoreList": []
 }


### PR DESCRIPTION
fixes #210 

Famous last words: it should be impossible for 2 solutions to reference the same tsconfig within in a setup that shares one tsconfck cache. If that were the case, this fix could be wrong because then there are 2 different values for configDir but only one cache.


