### PR TITLE
chore: add node 24 to test matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # pseudo-matrix for convenience, NEVER use more than a single combination
-        node: [20]
+        node: [22]
         os: [ubuntu-latest]
     steps:
       - name: checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,8 @@ jobs:
         ts: ['current']
         include:
           - node: 18
-          - os: ubuntu-latest
-          - ts: 'current'
+            os: ubuntu-latest
+            ts: 'current'
           - node: 20
             os: ubuntu-latest
             ts: 'current'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # pseudo-matrix for convenience, NEVER use more than a single combination
-        node: [20]
+        node: [22]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
@@ -57,17 +57,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20]
+        node: [22]
         os: [ubuntu-latest, macos-latest, windows-latest]
         ts: ['current']
         include:
           - node: 18
+          - os: ubuntu-latest
+          - ts: 'current'
+          - node: 20
+            os: ubuntu-latest
+            ts: 'current'
+          - node: 24
             os: ubuntu-latest
             ts: 'current'
           - node: 22
-            os: ubuntu-latest
-            ts: 'current'
-          - node: 20
             os: ubuntu-latest
             ts: 'beta'
     steps:
@@ -86,6 +89,10 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
+      - id: disable_engine_strict
+        name: disable engine strict
+        if: matrix.node < 20
+        run: echo "engine-strict=false" >> .npmrc
       - name: install
         run: |
           pnpm install --frozen-lockfile --prefer-offline --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
 	},
 	"packageManager": "pnpm@10.11.0",
 	"engines": {
-		"node": "^18 || >=20"
+		"node": "^20 || ^22 || >=24"
 	}
 }

--- a/packages/tsconfck/tests/snapshots/parse/invalid/bom/tsconfig.json.error.node24.parse-native.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/bom/tsconfig.json.error.node24.parse-native.txt
@@ -1,0 +1,1 @@
+TS 1005: ',' expected.

--- a/packages/tsconfck/tests/snapshots/parse/invalid/bom/tsconfig.json.error.node24.parse.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/bom/tsconfig.json.error.node24.parse.txt
@@ -1,0 +1,4 @@
+parsing <fixture-dir>/parse/invalid/bom/tsconfig.json failed: SyntaxError: Unexpected token 'x', "{
+	"extends": x""
+}
+" is not valid JSON

--- a/packages/tsconfck/tests/snapshots/parse/invalid/comma/tsconfig.json.error.node24.parse-native.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/comma/tsconfig.json.error.node24.parse-native.txt
@@ -1,0 +1,1 @@
+TS 1136: Property assignment expected.

--- a/packages/tsconfck/tests/snapshots/parse/invalid/comma/tsconfig.json.error.node24.parse.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/comma/tsconfig.json.error.node24.parse.txt
@@ -1,0 +1,1 @@
+parsing <fixture-dir>/parse/invalid/comma/tsconfig.json failed: SyntaxError: Expected double-quoted property name in JSON at position 69 (line 5 column 6)

--- a/packages/tsconfck/tests/snapshots/parse/invalid/comments/tsconfig.json.error.node24.parse-native.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/comments/tsconfig.json.error.node24.parse-native.txt
@@ -1,0 +1,1 @@
+TS 1005: ',' expected.

--- a/packages/tsconfck/tests/snapshots/parse/invalid/comments/tsconfig.json.error.node24.parse.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/comments/tsconfig.json.error.node24.parse.txt
@@ -1,0 +1,1 @@
+parsing <fixture-dir>/parse/invalid/comments/tsconfig.json failed: SyntaxError: Expected ',' or '}' after property value in JSON at position 236 (line 14 column 7)

--- a/packages/tsconfck/tests/snapshots/parse/invalid/extends-array-circular/tsconfig.json.error.node24.parse-native.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/extends-array-circular/tsconfig.json.error.node24.parse-native.txt
@@ -1,0 +1,1 @@
+TS 18000: Circularity detected while resolving configuration: <fixture-dir>/parse/invalid/extends-array-circular/tsconfig.json -> <fixture-dir>/parse/invalid/extends-array-circular/tsconfig.a.json -> <fixture-dir>/parse/invalid/extends-array-circular/tsconfig.a.b.json -> <fixture-dir>/parse/invalid/extends-array-circular/tsconfig.a.json

--- a/packages/tsconfck/tests/snapshots/parse/invalid/extends-array-circular/tsconfig.json.error.node24.parse.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/extends-array-circular/tsconfig.json.error.node24.parse.txt
@@ -1,0 +1,1 @@
+Circular dependency in "extends": <fixture-dir>/parse/invalid/extends-array-circular/tsconfig.json -> <fixture-dir>/parse/invalid/extends-array-circular/tsconfig.b.json -> <fixture-dir>/parse/invalid/extends-array-circular/tsconfig.a.b.json -> <fixture-dir>/parse/invalid/extends-array-circular/tsconfig.a.json -> <fixture-dir>/parse/invalid/extends-array-circular/tsconfig.a.b.json

--- a/packages/tsconfck/tests/snapshots/parse/invalid/extends-circular/tsconfig.json.error.node24.parse-native.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/extends-circular/tsconfig.json.error.node24.parse-native.txt
@@ -1,0 +1,1 @@
+TS 18000: Circularity detected while resolving configuration: <fixture-dir>/parse/invalid/extends-circular/tsconfig.json -> <fixture-dir>/parse/invalid/extends-circular/tsconfig.circular.json -> <fixture-dir>/parse/invalid/extends-circular/deep/tsconfig.circular2.json -> <fixture-dir>/parse/invalid/extends-circular/tsconfig.json

--- a/packages/tsconfck/tests/snapshots/parse/invalid/extends-circular/tsconfig.json.error.node24.parse.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/extends-circular/tsconfig.json.error.node24.parse.txt
@@ -1,0 +1,1 @@
+Circular dependency in "extends": <fixture-dir>/parse/invalid/extends-circular/tsconfig.json -> <fixture-dir>/parse/invalid/extends-circular/tsconfig.circular.json -> <fixture-dir>/parse/invalid/extends-circular/deep/tsconfig.circular2.json -> <fixture-dir>/parse/invalid/extends-circular/tsconfig.json

--- a/packages/tsconfck/tests/snapshots/parse/invalid/extends-fallback-not-found/tsconfig.json.error.node24.parse-native.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/extends-fallback-not-found/tsconfig.json.error.node24.parse-native.txt
@@ -1,0 +1,1 @@
+TS 6053: File './dir' not found.

--- a/packages/tsconfck/tests/snapshots/parse/invalid/extends-fallback-not-found/tsconfig.json.error.node24.parse.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/extends-fallback-not-found/tsconfig.json.error.node24.parse.txt
@@ -1,0 +1,1 @@
+failed to resolve "extends":"./dir" in <fixture-dir>/parse/invalid/extends-fallback-not-found/tsconfig.json

--- a/packages/tsconfck/tests/snapshots/parse/invalid/extends-not-found/tsconfig.json.error.node24.parse-native.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/extends-not-found/tsconfig.json.error.node24.parse-native.txt
@@ -1,0 +1,1 @@
+TS 5083: Cannot read file '<fixture-dir>/parse/invalid/tsconfig.doesnotexist.json'.

--- a/packages/tsconfck/tests/snapshots/parse/invalid/extends-not-found/tsconfig.json.error.node24.parse.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/extends-not-found/tsconfig.json.error.node24.parse.txt
@@ -1,0 +1,1 @@
+failed to resolve "extends":"../tsconfig.doesnotexist.json" in <fixture-dir>/parse/invalid/extends-not-found/tsconfig.json

--- a/packages/tsconfck/tests/snapshots/parse/invalid/mixed/tsconfig.json.error.node24.parse-native.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/mixed/tsconfig.json.error.node24.parse-native.txt
@@ -1,0 +1,1 @@
+TS 1005: ',' expected.

--- a/packages/tsconfck/tests/snapshots/parse/invalid/mixed/tsconfig.json.error.node24.parse.txt
+++ b/packages/tsconfck/tests/snapshots/parse/invalid/mixed/tsconfig.json.error.node24.parse.txt
@@ -1,0 +1,1 @@
+parsing <fixture-dir>/parse/invalid/mixed/tsconfig.json failed: SyntaxError: Expected ',' or '}' after property value in JSON at position 297 (line 16 column 5)


### PR DESCRIPTION
bump engine but keep fallback test for node18 (still present in tsconfck engines)