### PR TITLE
fix: typecheck and fix internal types

### DIFF
--- a/.changeset/hip-peas-admire.md
+++ b/.changeset/hip-peas-admire.md
@@ -1,0 +1,5 @@
+---
+'tsconfck': patch
+---
+
+fix types

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,13 +17,13 @@ export function find(filename: string, options?: TSConfckFindOptions): Promise<s
 #### TSConfckFindOptions
 
 ```ts
-export interface TSConfckFindOptions {
+export interface TSConfckFindOptions<T = TSConfckParseResult | TSConfckParseNativeResult> {
 	/**
 	 * A cache to improve performance for multiple calls in the same project
 	 *
 	 * Warning: You must clear this cache in case tsconfig files are added/removed during it's lifetime
 	 */
-	cache?: TSConfckCache<TSConfckParseResult | TSConfckParseNativeResult>;
+	cache?: TSConfckCache<T>;
 
 	/**
 	 * project root dir, does not continue scanning outside of this directory.
@@ -67,7 +67,7 @@ export function parse(filename: string, options?: TSConfckParseOptions): Promise
 #### TSConfckParseOptions
 
 ```ts
-export interface TSConfckParseOptions extends TSConfckFindOptions {
+export interface TSConfckParseOptions extends TSConfckFindOptions<TSConfckParseResult> {
 	// same as find options
 }
 ```
@@ -116,7 +116,7 @@ export class TSConfckParseError extends Error {
 	 * @param tsconfigFile - path to tsconfig file
 	 * @param cause - cause of this error
 	 */
-	constructor(message: string, code: string, tsconfigFile: string, cause: Error | null);
+	constructor(message: string, code: string, tsconfigFile: string, cause?: Error);
 	/**
 	 * error code
 	 * */
@@ -164,7 +164,7 @@ export function parseNative(filename: string, options?: TSConfckParseNativeOptio
 #### TSConfckParseNativeOptions
 
 ```ts
-export interface TSConfckParseNativeOptions extends TSConfckParseOptions {
+export interface TSConfckParseNativeOptions extends TSConfckFindOptions<TSConfckParseNativeResult> {
 	/**
 	 * Set this option to true to force typescript to ignore all source files.
 	 *

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@changesets/cli": "^2.29.7",
 		"@eslint/js": "^9.35.0",
 		"@svitejs/changesets-changelog-github-compact": "^1.2.0",
+		"@types/node": "^24.8.1",
 		"dts-buddy": "^0.6.2",
 		"esbuild": "^0.25.9",
 		"eslint": "^9.35.0",

--- a/packages/tsconfck/bin/tsconfck.js
+++ b/packages/tsconfck/bin/tsconfck.js
@@ -23,6 +23,9 @@ parse tsconfig for a file
 const HELP_ARGS = ['-h', '--help', '-?', 'help'];
 const JS_ARG = '-js';
 const COMMANDS = ['find', 'find-all', 'find-all', 'parse', 'parse-result'];
+/**
+ * @param {string[]} args
+ */
 function needsHelp(args) {
 	if (args.some((arg) => HELP_ARGS.includes(arg))) {
 		return HELP_TEXT;
@@ -65,7 +68,7 @@ async function main() {
 
 main().then(
 	(result) => {
-		process.stdout.write(result);
+		process.stdout.write(result ?? '');
 		process.stdout.write('\n');
 	},
 	(err) => {

--- a/packages/tsconfck/package.json
+++ b/packages/tsconfck/package.json
@@ -62,10 +62,10 @@
 	},
 	"scripts": {
 		"check:publint": "publint --strict",
-		"check:types": "tsc --noEmit",
+		"check:types": "tsc",
 		"test": "vitest run",
 		"test:coverage": "vitest run --coverage",
 		"test:watch": "vitest",
-		"dts-buddy": "dts-buddy -m \"tsconfck:src/index.js\""
+		"dts-buddy": "dts-buddy -m tsconfck:src/public.d.ts"
 	}
 }

--- a/packages/tsconfck/src/cache.js
+++ b/packages/tsconfck/src/cache.js
@@ -28,8 +28,9 @@ export class TSConfckCache {
 	getConfigPath(dir, configName = 'tsconfig.json') {
 		const key = `${dir}/${configName}`;
 		const value = this.#configPaths.get(key);
+		// @ts-expect-error loosely check string or promise type
 		if (value == null || value.length || value.then) {
-			return value;
+			return value ?? null;
 		} else {
 			throw value;
 		}
@@ -52,7 +53,8 @@ export class TSConfckCache {
 	 */
 	getParseResult(file) {
 		const value = this.#parsed.get(file);
-		if (value.then || value.tsconfig) {
+		// @ts-expect-error loosely check promise or tsconfig type
+		if (value && (value.then || value.tsconfig)) {
 			return value;
 		} else {
 			throw value; // cached error, rethrow
@@ -62,7 +64,7 @@ export class TSConfckCache {
 	/**
 	 * @internal
 	 * @private
-	 * @param file
+	 * @param {string} file
 	 * @param {boolean} isRootFile a flag to check if current file which involking the parse() api, used to distinguish the normal cache which only parsed by parseFile()
 	 * @param {Promise<T>} result
 	 */
@@ -114,7 +116,6 @@ export class TSConfckCache {
 	/**
 	 * map directories to their closest tsconfig.json
 	 * @internal
-	 * @private
 	 * @type{Map<string,(Promise<string|null>|string|null)>}
 	 */
 	#configPaths = new Map();
@@ -122,7 +123,6 @@ export class TSConfckCache {
 	/**
 	 * map files to their parsed tsconfig result
 	 * @internal
-	 * @private
 	 * @type {Map<string,(Promise<T>|T)> }
 	 */
 	#parsed = new Map();

--- a/packages/tsconfck/src/find-all.js
+++ b/packages/tsconfck/src/find-all.js
@@ -2,11 +2,10 @@ import path from 'node:path';
 import { readdir } from 'node:fs';
 
 /**
- * @typedef WalkState
- * @interface
+ * @typedef {Object} WalkState
  * @property {string[]} files - files
  * @property {number} calls - number of ongoing calls
- * @property {(dir: string)=>boolean} skip - function to skip dirs
+ * @property {(dir: string)=>boolean} [skip] - function to skip dirs
  * @property {boolean} err - error flag
  * @property {string[]} configNames - config file names
  */
@@ -38,7 +37,7 @@ export async function findAll(dir, options) {
  *
  * @param {string} dir
  * @param {WalkState} state
- * @param {(err: NodeJS.ErrnoException | null, files?: string[]) => void} done
+ * @param {(err: NodeJS.ErrnoException | null, files: string[]) => void} done
  */
 function walk(dir, state, done) {
 	if (state.err) {
@@ -52,7 +51,7 @@ function walk(dir, state, done) {
 		// skip deleted or inaccessible directories
 		if (err && !(err.code === 'ENOENT' || err.code === 'EACCES' || err.code === 'EPERM')) {
 			state.err = true;
-			done(err);
+			done(err, []);
 		} else {
 			for (const ent of entries) {
 				if (ent.isDirectory() && !state.skip?.(ent.name)) {

--- a/packages/tsconfck/src/find-native.js
+++ b/packages/tsconfck/src/find-native.js
@@ -13,12 +13,15 @@ import { isInNodeModules, loadTS, native2posix } from './util.js';
 export async function findNative(filename, options) {
 	let dir = native2posix(path.dirname(path.resolve(filename)));
 	if (options?.ignoreNodeModules && isInNodeModules(dir)) {
+		// TODO: This returns a different type than the function signature says. Fix this in another PR.
+		// @ts-expect-error
 		return null;
 	}
 	const cache = options?.cache;
 	const root = options?.root ? native2posix(path.resolve(options.root)) : undefined;
 	const configName = options?.configName ?? 'tsconfig.json';
 	if (cache?.hasConfigPath(dir, configName)) {
+		// @ts-expect-error This never returns null
 		return cache.getConfigPath(dir, configName);
 	}
 	const ts = await loadTS();
@@ -36,7 +39,7 @@ export async function findNative(filename, options) {
 /**
  *
  * @param {string} tsconfigFile
- * @param {string} root
+ * @param {string} [root]
  */
 function is_out_of_root(tsconfigFile, root) {
 	return root && !tsconfigFile.startsWith(root);
@@ -47,7 +50,7 @@ function is_out_of_root(tsconfigFile, root) {
  * if no tsconfig was found, go up until root
  * @param {string|null} tsconfigFile
  * @param {string} fileDir
- * @param {import('./cache.js').TSConfckCache} cache
+ * @param {import('./cache.js').TSConfckCache<import('./public.d.ts').TSConfckParseResult | import('./public.d.ts').TSConfckParseNativeResult>} cache
  * @param {string|undefined} root
  * @param {string} configName
  */
@@ -65,6 +68,7 @@ function cache_result(tsconfigFile, fileDir, cache, root, configName) {
 		}
 	}
 	directories.forEach((d) => {
+		// @ts-expect-error accessing private method because dts-buddy can't strip internal types for some reason
 		cache.setConfigPath(d, Promise.resolve(tsconfigFile), configName);
 	});
 }

--- a/packages/tsconfck/src/find.js
+++ b/packages/tsconfck/src/find.js
@@ -43,12 +43,15 @@ function findUp(dir, { resolve, reject, promise }, options) {
 				reject(e);
 				return;
 			}
+
+			// @ts-expect-error loosely check promise
 			if (cached?.then) {
-				cached.then(resolve).catch(reject);
+				/** @type {Promise<string | null>} */ (cached).then(resolve).catch(reject);
 			} else {
-				resolve(cached);
+				resolve(/** @type {string | null} */ (cached));
 			}
 		} else {
+			// @ts-expect-error accessing private method because dts-buddy can't strip internal types for some reason
 			cache.setConfigPath(dir, promise, configName);
 		}
 	}

--- a/packages/tsconfck/src/parse-native.js
+++ b/packages/tsconfck/src/parse-native.js
@@ -10,6 +10,8 @@ import {
 } from './util.js';
 import { findNative } from './find-native.js';
 
+/** @typedef {import('./cache.js').TSConfckCache<import('./public.d.ts').TSConfckParseNativeResult>} ParseNativeCache  */
+
 const notFoundResult = {
 	tsconfigFile: null,
 	tsconfig: {},
@@ -27,7 +29,7 @@ const notFoundResult = {
  * @throws {TSConfckParseNativeError}
  */
 export async function parseNative(filename, options) {
-	/** @type {import('./cache.js').TSConfckCache} */
+	/** @type {ParseNativeCache | undefined} */
 	const cache = options?.cache;
 	if (cache?.hasParseResult(filename)) {
 		return cache.getParseResult(filename);
@@ -38,6 +40,7 @@ export async function parseNative(filename, options) {
 		/** @type {Promise<import('./public.d.ts').TSConfckParseNativeResult>}*/
 		promise
 	} = makePromise();
+	// @ts-expect-error accessing private method because dts-buddy can't strip internal types for some reason
 	cache?.setParseResult(filename, promise);
 	try {
 		const tsconfigFile =
@@ -54,6 +57,7 @@ export async function parseNative(filename, options) {
 			const ts = await loadTS();
 			result = await parseFile(tsconfigFile, ts, options, filename === tsconfigFile);
 			await parseReferences(result, ts, options);
+			// @ts-expect-error accessing private method because dts-buddy can't strip internal types for some reason
 			cache?.setParseResult(tsconfigFile, Promise.resolve(result));
 		}
 
@@ -71,12 +75,12 @@ export async function parseNative(filename, options) {
  * @param {any} ts
  * @param {import('./public.d.ts').TSConfckParseNativeOptions} [options]
  * @param {boolean} [skipCache]
- * @returns {import('./public.d.ts').TSConfckParseNativeResult}
+ * @returns {Promise<import('./public.d.ts').TSConfckParseNativeResult>}
  */
-function parseFile(tsconfigFile, ts, options, skipCache) {
+async function parseFile(tsconfigFile, ts, options, skipCache) {
 	const cache = options?.cache;
 	if (!skipCache && cache?.hasParseResult(tsconfigFile)) {
-		return cache.getParseResult(tsconfigFile);
+		return await cache.getParseResult(tsconfigFile);
 	}
 	const posixTSConfigFile = native2posix(tsconfigFile);
 	const { parseJsonConfigFileContent, readConfigFile, sys } = ts;
@@ -114,6 +118,7 @@ function parseFile(tsconfigFile, ts, options, skipCache) {
 	};
 
 	if (!skipCache) {
+		// @ts-expect-error accessing private method because dts-buddy can't strip internal types for some reason
 		cache?.setParseResult(tsconfigFile, Promise.resolve(result));
 	}
 
@@ -154,7 +159,8 @@ function checkErrors(nativeResult, tsconfigFile) {
 		18003 // no inputs
 	];
 	const criticalError = nativeResult.errors?.find(
-		(error) => error.category === 1 && !ignoredErrorCodes.includes(error.code)
+		(/** @type {TSDiagnosticError} */ error) =>
+			error.category === 1 && !ignoredErrorCodes.includes(error.code)
 	);
 	if (criticalError) {
 		throw new TSConfckParseNativeError(criticalError, tsconfigFile, nativeResult);
@@ -192,7 +198,7 @@ function result2tsconfig(result, ts, tsconfigFile) {
 	if (compilerOptions) {
 		if (compilerOptions.lib != null) {
 			// remove lib. and .dts from lib.es2019.d.ts etc
-			compilerOptions.lib = compilerOptions.lib.map((x) =>
+			compilerOptions.lib = compilerOptions.lib.map((/** @type {string} */ x) =>
 				x.replace(/^lib\./, '').replace(/\.d\.ts$/, '')
 			);
 		}
@@ -297,9 +303,9 @@ export class TSConfckParseNativeError extends Error {
 	result;
 }
 
-/** @typedef TSDiagnosticError {
+/** @typedef {{
 	code: number;
 	category: number;
 	messageText: string;
 	start?: number;
-} TSDiagnosticError */
+}} TSDiagnosticError */

--- a/packages/tsconfck/src/parse.js
+++ b/packages/tsconfck/src/parse.js
@@ -13,6 +13,8 @@ import {
 	resolveTSConfigJson
 } from './util.js';
 
+/** @typedef {import('./cache.js').TSConfckCache<import('./public.d.ts').TSConfckParseResult>} ParseCache  */
+
 const not_found_result = {
 	tsconfigFile: null,
 	tsconfig: {}
@@ -27,22 +29,21 @@ const not_found_result = {
  * @throws {TSConfckParseError}
  */
 export async function parse(filename, options) {
-	/** @type {import('./cache.js').TSConfckCache} */
+	/** @type {ParseCache | undefined} */
 	const cache = options?.cache;
 	if (cache?.hasParseResult(filename)) {
 		return getParsedDeep(filename, cache, options);
 	}
-	const {
-		resolve,
-		reject,
-		/** @type {Promise<import('./public.d.ts').TSConfckParseResult>}*/
-		promise
-	} = makePromise();
+	/** @type {import('./util.js').PromiseWithResolvers<import('./public.d.ts').TSConfckParseResult>} */
+	const { resolve, reject, promise } = makePromise();
+	// @ts-expect-error accessing private method because dts-buddy can't strip internal types for some reason
 	cache?.setParseResult(filename, promise, true);
 	try {
 		let tsconfigFile =
 			(await resolveTSConfigJson(filename, cache)) || (await find(filename, options));
 		if (!tsconfigFile) {
+			// TODO: This returns a different type than the function signature says. Fix this in another PR.
+			// @ts-expect-error
 			resolve(not_found_result);
 			return promise;
 		}
@@ -65,8 +66,8 @@ export async function parse(filename, options) {
  * ensure extends and references are parsed
  *
  * @param {string} filename - cached file
- * @param {import('./cache.js').TSConfckCache} cache - cache
- * @param {import('./public.d.ts').TSConfckParseOptions} options - options
+ * @param {ParseCache} cache - cache
+ * @param {import('./public.d.ts').TSConfckParseOptions} [options] - options
  */
 async function getParsedDeep(filename, cache, options) {
 	const result = await cache.getParseResult(filename);
@@ -78,6 +79,7 @@ async function getParsedDeep(filename, cache, options) {
 			parseExtends(result, cache),
 			parseReferences(result, options)
 		]).then(() => result);
+		// @ts-expect-error accessing private method because dts-buddy can't strip internal types for some reason
 		cache.setParseResult(filename, promise, true);
 		return promise;
 	}
@@ -87,7 +89,7 @@ async function getParsedDeep(filename, cache, options) {
 /**
  *
  * @param {string} tsconfigFile - path to tsconfig file
- * @param {import('./cache.js').TSConfckCache} [cache] - cache
+ * @param {ParseCache} [cache] - cache
  * @param {boolean} [skipCache] - skip cache
  * @returns {Promise<import('./public.d.ts').TSConfckParseResult>}
  */
@@ -95,7 +97,7 @@ async function parseFile(tsconfigFile, cache, skipCache) {
 	if (
 		!skipCache &&
 		cache?.hasParseResult(tsconfigFile) &&
-		!cache.getParseResult(tsconfigFile)._isRootFile_
+		!('_isRootFile_' in cache.getParseResult(tsconfigFile))
 	) {
 		return cache.getParseResult(tsconfigFile);
 	}
@@ -120,8 +122,10 @@ async function parseFile(tsconfigFile, cache, skipCache) {
 		});
 	if (
 		!skipCache &&
-		(!cache?.hasParseResult(tsconfigFile) || !cache.getParseResult(tsconfigFile)._isRootFile_)
+		(!cache?.hasParseResult(tsconfigFile) ||
+			!('_isRootFile_' in cache.getParseResult(tsconfigFile)))
 	) {
+		// @ts-expect-error accessing private method because dts-buddy can't strip internal types for some reason
 		cache?.setParseResult(tsconfigFile, promise);
 	}
 	return promise;
@@ -166,7 +170,7 @@ async function parseReferences(result, options) {
 
 /**
  * @param {import('./public.d.ts').TSConfckParseResult} result
- * @param {import('./cache.js').TSConfckCache}[cache]
+ * @param {ParseCache} [cache]
  * @returns {Promise<void>}
  */
 async function parseExtends(result, cache) {
@@ -199,7 +203,7 @@ async function parseExtends(result, cache) {
 				// reverse because typescript 5.0 treats ['a','b','c'] as c extends b extends a
 				resolvedExtends = extending.tsconfig.extends
 					.reverse()
-					.map((ex) => resolveExtends(ex, extending.tsconfigFile));
+					.map((/** @type {string} */ ex) => resolveExtends(ex, extending.tsconfigFile));
 			}
 
 			const circularExtends = resolvedExtends.find((tsconfigFile) =>
@@ -245,17 +249,18 @@ function resolveExtends(extended, from) {
 		extended = extended + '/tsconfig.json';
 	}
 	const req = createRequire(from);
+	/** @type {Error | undefined} */
 	let error;
 	try {
 		return req.resolve(extended);
 	} catch (e) {
-		error = e;
+		error = /** @type {Error} */ (e);
 	}
 	if (extended[0] !== '.' && !path.isAbsolute(extended)) {
 		try {
 			return req.resolve(`${extended}/tsconfig.json`);
 		} catch (e) {
-			error = e;
+			error = /** @type {Error} */ (e);
 		}
 	}
 
@@ -398,7 +403,7 @@ export class TSConfckParseError extends Error {
 	 * @param {string} message - error message
 	 * @param {string} code - error code
 	 * @param {string} tsconfigFile - path to tsconfig file
-	 * @param {Error?} cause - cause of this error
+	 * @param {Error} [cause] - cause of this error
 	 */
 	constructor(message, code, tsconfigFile, cause) {
 		super(message);

--- a/packages/tsconfck/src/public.d.ts
+++ b/packages/tsconfck/src/public.d.ts
@@ -1,12 +1,12 @@
 import { TSConfckCache } from './cache.js';
 
-export interface TSConfckFindOptions {
+export interface TSConfckFindOptions<T = TSConfckParseResult | TSConfckParseNativeResult> {
 	/**
 	 * A cache to improve performance for multiple calls in the same project
 	 *
 	 * Warning: You must clear this cache in case tsconfig files are added/removed during it's lifetime
 	 */
-	cache?: TSConfckCache<TSConfckParseResult | TSConfckParseNativeResult>;
+	cache?: TSConfckCache<T>;
 
 	/**
 	 * project root dir, does not continue scanning outside of this directory.
@@ -34,7 +34,7 @@ export interface TSConfckFindOptions {
 	configName?: string;
 }
 
-export interface TSConfckParseOptions extends TSConfckFindOptions {
+export interface TSConfckParseOptions extends TSConfckFindOptions<TSConfckParseResult> {
 	// same as find options
 }
 
@@ -82,7 +82,7 @@ export interface TSConfckParseResult {
 	extended?: TSConfckParseResult[];
 }
 
-export interface TSConfckParseNativeOptions extends TSConfckParseOptions {
+export interface TSConfckParseNativeOptions extends TSConfckFindOptions<TSConfckParseNativeResult> {
 	/**
 	 * Set this option to true to force typescript to ignore all source files.
 	 *

--- a/packages/tsconfck/src/to-json.js
+++ b/packages/tsconfck/src/to-json.js
@@ -84,8 +84,8 @@ function isEscaped(jsonString, quotePosition) {
 /**
  *
  * @param {string} string
- * @param {number?} start
- * @param {number?} end
+ * @param {number} [start]
+ * @param {number} [end]
  */
 function strip(string, start, end) {
 	return string.slice(start, end).replace(/\S/g, ' ');

--- a/packages/tsconfck/src/util.js
+++ b/packages/tsconfck/src/util.js
@@ -15,16 +15,29 @@ const TSJS_EXTENSIONS_RE_GROUP = `\\.(?:${TSJS_EXTENSIONS.map((ext) => ext.subst
 )})`;
 const IS_POSIX = path.posix.sep === path.sep;
 
+// https://github.com/microsoft/TypeScript/blob/d3be7e171bf3149fe93c3ce5a85280f1eba3ef8d/src/lib/es2024.promise.d.ts#L1-L5
 /**
  * @template T
- * @returns {{resolve:(result:T)=>void, reject:(error:any)=>void, promise: Promise<T>}}
+ * @typedef {Object} PromiseWithResolvers
+ * @property {Promise<T>} promise
+ * @property {(value: T | PromiseLike<T>) => void} resolve
+ * @property {(reason?: any) => void} reject
+ */
+
+/**
+ * @template T
+ * @returns {PromiseWithResolvers<T>}
  */
 export function makePromise() {
-	let resolve, reject;
+	/** @type {(value: T | PromiseLike<T>) => void} */
+	let resolve;
+	/** @type {(reason?: any) => void} */
+	let reject;
 	const promise = new Promise((res, rej) => {
 		resolve = res;
 		reject = rej;
 	});
+	// @ts-expect-error we know `resolve` and `reject` are assigned in the constructor
 	return { promise, resolve, reject };
 }
 
@@ -43,7 +56,8 @@ export async function loadTS() {
 
 /**
  * @param {string} filename
- * @param {import('./cache.js').TSConfckCache} [cache]
+ * @param {import('./cache.js').TSConfckCache<T>} [cache]
+ * @template T
  * @returns {Promise<string|void>}
  */
 export async function resolveTSConfigJson(filename, cache) {
@@ -69,8 +83,8 @@ export async function resolveTSConfigJson(filename, cache) {
  * @returns {boolean}  if dir path includes a node_modules segment
  */
 export const isInNodeModules = IS_POSIX
-	? (dir) => dir.includes('/node_modules/')
-	: (dir) => dir.match(/[/\\]node_modules[/\\]/);
+	? (/** @type {string} */ dir) => dir.includes('/node_modules/')
+	: (/** @type {string} */ dir) => dir.match(/[/\\]node_modules[/\\]/);
 
 /**
  * convert posix separator to native separator
@@ -82,9 +96,9 @@ export const isInNodeModules = IS_POSIX
  * @param {string} filename with posix separators
  * @returns {string} filename with native separators
  */
-export const posix2native = IS_POSIX
-	? (filename) => filename
-	: (filename) => filename.replace(POSIX_SEP_RE, path.sep);
+export const posix2native = (filename) => {
+	return IS_POSIX ? filename : filename.replace(POSIX_SEP_RE, path.sep);
+};
 
 /**
  * convert native separator to posix separator
@@ -96,9 +110,9 @@ export const posix2native = IS_POSIX
  * @param {string} filename - filename with native separators
  * @returns {string} filename with posix separators
  */
-export const native2posix = IS_POSIX
-	? (filename) => filename
-	: (filename) => filename.replace(NATIVE_SEP_RE, path.posix.sep);
+export const native2posix = (filename) => {
+	return IS_POSIX ? filename : filename.replace(NATIVE_SEP_RE, path.posix.sep);
+};
 
 /**
  * converts params to native separator, resolves path and converts native back to posix
@@ -109,14 +123,17 @@ export const native2posix = IS_POSIX
  * @param filename {string} filename or pattern to resolve
  * @returns string
  */
-export const resolve2posix = IS_POSIX
-	? (dir, filename) => (dir ? path.resolve(dir, filename) : path.resolve(filename))
-	: (dir, filename) =>
-			native2posix(
-				dir
-					? path.resolve(posix2native(dir), posix2native(filename))
-					: path.resolve(posix2native(filename))
-			);
+export const resolve2posix = (dir, filename) => {
+	if (IS_POSIX) {
+		return dir ? path.resolve(dir, filename) : path.resolve(filename);
+	} else {
+		return native2posix(
+			dir
+				? path.resolve(posix2native(dir), posix2native(filename))
+				: path.resolve(posix2native(filename))
+		);
+	}
+};
 
 /**
  *
@@ -126,7 +143,7 @@ export const resolve2posix = IS_POSIX
  */
 export function resolveReferencedTSConfigFiles(result, options) {
 	const dir = path.dirname(result.tsconfigFile);
-	return result.tsconfig.references.map((ref) => {
+	return result.tsconfig.references.map((/** @type {{ path: string }} */ ref) => {
 		const refPath = ref.path.endsWith('.json')
 			? ref.path
 			: path.join(ref.path, options?.configName ?? 'tsconfig.json');
@@ -165,7 +182,9 @@ export function resolveSolutionTSConfig(filename, result) {
  */
 function isIncluded(filename, result) {
 	const dir = native2posix(path.dirname(result.tsconfigFile));
-	const files = (result.tsconfig.files || []).map((file) => resolve2posix(dir, file));
+	const files = (result.tsconfig.files || []).map((/** @type {string} */ file) =>
+		resolve2posix(dir, file)
+	);
 	const absoluteFilename = resolve2posix(null, filename);
 	if (files.includes(filename)) {
 		return true;
@@ -279,6 +298,7 @@ export function isGlobMatch(filename, dir, patterns, allowJs) {
 		}
 		// complex pattern, use regex to check it
 		if (PATTERN_REGEX_CACHE.has(resolvedPattern)) {
+			// @ts-expect-error `.get` will never return undefined
 			return PATTERN_REGEX_CACHE.get(resolvedPattern).test(filename);
 		}
 		const regex = pattern2regex(resolvedPattern, allowJs);

--- a/packages/tsconfck/tests/find-native.js
+++ b/packages/tsconfck/tests/find-native.js
@@ -199,8 +199,8 @@ describe('find-native', () => {
 		expect(cache.getConfigPath(posixAbsFix(`${fixtureDir}`))).toBe(expectedTSConfig);
 		expect(cache.getConfigPath(posixAbsFix(`${fixtureDir}/b`))).toBe(expectedTSConfig);
 		expect(cache.getConfigPath(posixAbsFix(`${fixtureDir}/b/c`))).toBe(expectedTSConfig);
-		expect(cache.getConfigPath(posixAbsFix(`${fixtureDir}`), 'jsconfig.json')).toBe(undefined);
-		expect(cache.getConfigPath(posixAbsFix(`${fixtureDir}/b`), 'jsconfig.json')).toBe(undefined);
+		expect(cache.getConfigPath(posixAbsFix(`${fixtureDir}`), 'jsconfig.json')).toBe(null);
+		expect(cache.getConfigPath(posixAbsFix(`${fixtureDir}/b`), 'jsconfig.json')).toBe(null);
 		expect(cache.getConfigPath(posixAbsFix(`${fixtureDir}/b/c`), 'jsconfig.json')).toBe(
 			expectedJSConfig
 		);

--- a/packages/tsconfck/tests/find.js
+++ b/packages/tsconfck/tests/find.js
@@ -185,8 +185,8 @@ describe('find', () => {
 		expect(cache.getConfigPath(absFixture(`${fixtureDir}`))).toBe(expectedTSConfig);
 		expect(cache.getConfigPath(absFixture(`${fixtureDir}/b`))).toBe(expectedTSConfig);
 		expect(cache.getConfigPath(absFixture(`${fixtureDir}/b/c`))).toBe(expectedTSConfig);
-		expect(cache.getConfigPath(absFixture(`${fixtureDir}`), 'jsconfig.json')).toBe(undefined);
-		expect(cache.getConfigPath(absFixture(`${fixtureDir}/b`), 'jsconfig.json')).toBe(undefined);
+		expect(cache.getConfigPath(absFixture(`${fixtureDir}`), 'jsconfig.json')).toBe(null);
+		expect(cache.getConfigPath(absFixture(`${fixtureDir}/b`), 'jsconfig.json')).toBe(null);
 		expect(cache.getConfigPath(absFixture(`${fixtureDir}/b/c`), 'jsconfig.json')).toBe(
 			expectedJSConfig
 		);

--- a/packages/tsconfck/tsconfig.json
+++ b/packages/tsconfck/tsconfig.json
@@ -6,7 +6,9 @@
 		"target": "es2022",
 		"moduleResolution": "bundler",
 		"strict": true,
-		"allowJs": true
+		"allowJs": true,
+		"checkJs": true,
+		"noEmit": true
 	},
 	"include": ["bin/**/*", "src/**/*", "types/**/*"],
 	"exclude": ["node_modules"]

--- a/packages/tsconfck/types/index.d.ts
+++ b/packages/tsconfck/types/index.d.ts
@@ -1,11 +1,11 @@
 declare module 'tsconfck' {
-	export interface TSConfckFindOptions {
+	export interface TSConfckFindOptions<T = TSConfckParseResult | TSConfckParseNativeResult> {
 		/**
 		 * A cache to improve performance for multiple calls in the same project
 		 *
 		 * Warning: You must clear this cache in case tsconfig files are added/removed during it's lifetime
 		 */
-		cache?: TSConfckCache<TSConfckParseResult | TSConfckParseNativeResult>;
+		cache?: TSConfckCache<T>;
 
 		/**
 		 * project root dir, does not continue scanning outside of this directory.
@@ -33,7 +33,7 @@ declare module 'tsconfck' {
 		configName?: string;
 	}
 
-	export interface TSConfckParseOptions extends TSConfckFindOptions {
+	export interface TSConfckParseOptions extends TSConfckFindOptions<TSConfckParseResult> {
 		// same as find options
 	}
 
@@ -81,7 +81,7 @@ declare module 'tsconfck' {
 		extended?: TSConfckParseResult[];
 	}
 
-	export interface TSConfckParseNativeOptions extends TSConfckParseOptions {
+	export interface TSConfckParseNativeOptions extends TSConfckFindOptions<TSConfckParseNativeResult> {
 		/**
 		 * Set this option to true to force typescript to ignore all source files.
 		 *
@@ -198,7 +198,7 @@ declare module 'tsconfck' {
 		 * @param tsconfigFile - path to tsconfig file
 		 * @param cause - cause of this error
 		 */
-		constructor(message: string, code: string, tsconfigFile: string, cause: Error | null);
+		constructor(message: string, code: string, tsconfigFile: string, cause?: Error);
 		/**
 		 * error code
 		 * */
@@ -246,15 +246,12 @@ declare module 'tsconfck' {
 		 * */
 		tsconfigFile: string;
 	}
-	/**
-	 * {
-	 * code: number;
-	 * category: number;
-	 * messageText: string;
-	 * start?: number;
-	 * } TSDiagnosticError
-	 */
-	type TSDiagnosticError = any;
+	type TSDiagnosticError = {
+		code: number;
+		category: number;
+		messageText: string;
+		start?: number;
+	};
 
 	export {};
 }

--- a/packages/tsconfck/types/index.d.ts.map
+++ b/packages/tsconfck/types/index.d.ts.map
@@ -16,8 +16,7 @@
 		"parse",
 		"TSConfckParseError",
 		"parseNative",
-		"TSConfckParseNativeError",
-		"TSDiagnosticError"
+		"TSConfckParseNativeError"
 	],
 	"sources": [
 		"../src/public.d.ts",
@@ -27,8 +26,7 @@
 		"../src/to-json.js",
 		"../src/find-native.js",
 		"../src/parse.js",
-		"../src/parse-native.js",
-		"../src/parse-native.d.ts"
+		"../src/parse-native.js"
 	],
 	"sourcesContent": [
 		null,
@@ -38,9 +36,8 @@
 		null,
 		null,
 		null,
-		null,
 		null
 	],
-	"mappings": ";kBAEiBA,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAkCnBC,oBAAoBA;;;;kBAIpBC,sBAAsBA;;;;;;;;;;;;;;;kBAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBA6BnBC,0BAA0BA;;;;;;;;;;;;kBAY1BC,yBAAyBA;;;;;;;;;;;;;;;;;;;;;;;;;;cC/F7BC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCSJC,IAAIA;;;;;;;;iBCYJC,OAAOA;;;;;;;iBCTbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;;;;;;;iBCgBVC,KAAKA;cA8VdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBC9VTC,WAAWA;cAoOpBC,wBAAwBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;MChNzBC,iBAAiBA",
+	"mappings": ";kBAEiBA,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBAkCnBC,oBAAoBA;;;;kBAIpBC,sBAAsBA;;;;;;;;;;;;;;;kBAetBC,mBAAmBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;kBA6BnBC,0BAA0BA;;;;;;;;;;;;kBAY1BC,yBAAyBA;;;;;;;;;;;;;;;;;;;;;;;;;;cC/F7BC,aAAaA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCSJC,IAAIA;;;;;;;;iBCWJC,OAAOA;;;;;;;iBCRbC,MAAMA;;;;;;;;;;iBCDAC,UAAUA;;;;;;;iBCkBVC,KAAKA;cAiWdC,kBAAkBA;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;iBCjWTC,WAAWA;cAwOpBC,wBAAwBA",
 	"ignoreList": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,16 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.7
-        version: 2.29.7
+        version: 2.29.7(@types/node@24.8.1)
       '@eslint/js':
         specifier: ^9.35.0
         version: 9.36.0
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.2.0
         version: 1.2.0
+      '@types/node':
+        specifier: ^24.8.1
+        version: 24.8.1
       dts-buddy:
         specifier: ^0.6.2
         version: 0.6.2(typescript@5.9.2)
@@ -70,7 +73,7 @@ importers:
         version: tsconfck@2.1.2(typescript@5.9.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(yaml@2.8.1)
+        version: 3.2.4(@types/node@24.8.1)(yaml@2.8.1)
 
   packages/tsconfck:
     devDependencies:
@@ -82,7 +85,7 @@ importers:
         version: 2.0.6
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(yaml@2.8.1))
+        version: 3.2.4(vitest@3.2.4(@types/node@24.8.1)(yaml@2.8.1))
       esbuild:
         specifier: ^0.25.9
         version: 0.25.10
@@ -97,7 +100,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(yaml@2.8.1)
+        version: 3.2.4(@types/node@24.8.1)(yaml@2.8.1)
 
 packages:
 
@@ -754,6 +757,9 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@24.8.1':
+    resolution: {integrity: sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1836,6 +1842,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.14.0:
+    resolution: {integrity: sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==}
+
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
 
@@ -2020,7 +2029,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.29.7':
+  '@changesets/cli@2.29.7(@types/node@24.8.1)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.13
       '@changesets/assemble-release-plan': 6.0.9
@@ -2036,7 +2045,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.1
+      '@inquirer/external-editor': 1.0.1(@types/node@24.8.1)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -2350,10 +2359,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.1':
+  '@inquirer/external-editor@1.0.1(@types/node@24.8.1)':
     dependencies:
       chardet: 2.1.0
       iconv-lite: 0.6.3
+    optionalDependencies:
+      '@types/node': 24.8.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2511,9 +2522,13 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@24.8.1':
+    dependencies:
+      undici-types: 7.14.0
+
   '@types/unist@2.0.11': {}
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(yaml@2.8.1))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@24.8.1)(yaml@2.8.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2528,7 +2543,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@24.8.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2540,13 +2555,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.0.11(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@6.0.11(@types/node@24.8.1)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.0.11(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.8.1)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3608,6 +3623,8 @@ snapshots:
 
   typescript@5.9.2: {}
 
+  undici-types@7.14.0: {}
+
   unist-util-stringify-position@2.0.3:
     dependencies:
       '@types/unist': 2.0.11
@@ -3618,13 +3635,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.4(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@24.8.1)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.0.11(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.8.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3639,20 +3656,21 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.0.11(yaml@2.8.1):
+  vite@6.0.11(@types/node@24.8.1)(yaml@2.8.1):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.1
       rollup: 4.31.0
     optionalDependencies:
+      '@types/node': 24.8.1
       fsevents: 2.3.3
       yaml: 2.8.1
 
-  vitest@3.2.4(yaml@2.8.1):
+  vitest@3.2.4(@types/node@24.8.1)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.0.11(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@6.0.11(@types/node@24.8.1)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3670,9 +3688,11 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.0.11(yaml@2.8.1)
-      vite-node: 3.2.4(yaml@2.8.1)
+      vite: 6.0.11(@types/node@24.8.1)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.8.1)(yaml@2.8.1)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.8.1
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
### Description

Fixes #234

Enabled typechecking for the `.js` files. Honestly, it doesn't seem like the library was written with typesafety in mind. I have to make a lot of fixes.

There's 2 possible/small breaking changes that I've left as TODO that can be fixed later or here depending on what solution you'd like to go with.

There's one small breaking change made in this PR needed to appease a lot of the internal types:

```ts
export interface TSConfckParseOptions extends TSConfckFindOptions<TSConfckParseResult> { ... }

export interface TSConfckParseNativeOptions extends TSConfckFindOptions<TSConfckParseNativeResult> { ... }
```

The `cache` property for these two options are now stricter (using the generics) so internally it's correctly accessing the properties.


